### PR TITLE
Add Scout extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.6.0
+
+- Added `Surgex.Scout` to support setting Scout Agent Key with `{:system, "SCOUT_API_KEY"}`
+
 ## 2.5.1
 
 - Fixed `Surgex.DeviseSession` to support `Plug.Conn` with `{:system, "SECRET_KEY_BASE"}`

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ publishing them separately. It currently consists of:
 - `Surgex.Parser`: parses, casts and catches errors in the web request input
 - `Surgex.PhoneNumber`: an `Ecto.Type` implementation of a E164-compilant phone numbers
 - `Surgex.Refactor`: tools for making code maintenance and refactors easier
+- `Surgex.Scout`: extensions to the official ScoutApm package
 - `Surgex.Sentry`: extensions to the official Sentry package
 
 ## Separate packages

--- a/lib/surgex/application.ex
+++ b/lib/surgex/application.ex
@@ -6,7 +6,10 @@ defmodule Surgex.Application do
   use Application
   use GenServer
   require Logger
-  alias Surgex.Sentry
+  alias Surgex.{
+    Scout,
+    Sentry,
+  }
 
   @doc false
   def start(_type, _args) do
@@ -14,6 +17,7 @@ defmodule Surgex.Application do
   end
 
   def init(_) do
+    Scout.init()
     Sentry.init()
 
     {:ok, nil, :hibernate}

--- a/lib/surgex/scout/scout.ex
+++ b/lib/surgex/scout/scout.ex
@@ -1,0 +1,43 @@
+defmodule Surgex.Scout do
+  @moduledoc """
+  Extensions to the official Scout package.
+  """
+
+  alias Surgex.Config
+
+  @doc """
+  Patches Scout environment key from env vars.
+
+  By default, ScoutApm package does not allow to fetch key from env var.
+
+  ## Examples
+
+  In order to execute this extension on application start, set an appropriate config key:
+
+      config :surgex,
+        scout_patch_enabled: true
+
+  """
+  def init do
+    if Application.get_env(:surgex, :scout_patch_enabled, false), do: do_init()
+  end
+
+  defp do_init do
+    require Logger
+
+    api_key = get_api_key()
+
+    Logger.info fn ->
+      "Patching Scout config (api_key: #{inspect api_key})"
+    end
+
+    Mix.Config.persist(scout_apm: [key: api_key])
+  end
+
+  defp get_api_key do
+    case Application.get_env(:surgex, :scout_api_key, "") do
+      value ->
+        Config.parse(value)
+    end
+  end
+end

--- a/lib/surgex/scout/scout.ex
+++ b/lib/surgex/scout/scout.ex
@@ -35,9 +35,8 @@ defmodule Surgex.Scout do
   end
 
   defp get_api_key do
-    case Application.get_env(:surgex, :scout_api_key, "") do
-      value ->
-        Config.parse(value)
-    end
+    :surgex
+    |> Application.get_env(:scout_api_key, "")
+    |> Config.parse()
   end
 end

--- a/test/surgex/scout/scout_test.exs
+++ b/test/surgex/scout/scout_test.exs
@@ -1,0 +1,23 @@
+defmodule Surgex.ScoutTest do
+  use ExUnit.Case
+  import ExUnit.CaptureLog
+  alias Mix.Config
+  alias Surgex.Scout
+
+  describe "init/0" do
+    test "patch enabled" do
+      System.put_env("SCOUT_API_KEY", "test_key")
+      Config.persist(surgex: [
+        scout_patch_enabled: true,
+        scout_api_key: {:system, "SCOUT_API_KEY"}
+      ])
+
+      log = capture_log(fn ->
+        Scout.init()
+      end)
+
+      assert log =~
+        ~s{Patching Scout config (api_key: "test_key")}
+    end
+  end
+end


### PR DESCRIPTION
Adds extension for ScoutApm package that allows to set api key with `{:system, "SCOUT_API_KEY"}`.