### PR TITLE
Add parser for handling single resource

### DIFF
--- a/lib/surgex/parser/parsers/resource_parser.ex
+++ b/lib/surgex/parser/parsers/resource_parser.ex
@@ -1,0 +1,13 @@
+defmodule Surgex.Parser.ResourceParser do
+  @moduledoc false
+
+  def call(nil, _item_parser), do: {:ok, nil}
+  def call(resource, item_parser) do
+    resource
+    |> item_parser.()
+    |> close()
+  end
+
+  defp close({:ok, result}), do: {:ok, result}
+  defp close({:error, :invalid_pointers, pointers}), do: {:error, pointers}
+end

--- a/test/surgex/parser/parsers/resource_parser_test.exs
+++ b/test/surgex/parser/parsers/resource_parser_test.exs
@@ -1,0 +1,24 @@
+defmodule Surgex.Parser.ResourceParserTest do
+  use ExUnit.Case
+  alias Surgex.Parser.ResourceParser
+
+  test "nil" do
+    assert ResourceParser.call(nil, fn _ -> nil end) == {:ok, nil}
+  end
+
+  test "valid input" do
+    assert ResourceParser.call(%{id: "123"}, fn resource ->
+      assert %{id: id} = resource
+
+      {:ok, [id: id]}
+    end) == {:ok, [id: "123"]}
+  end
+
+  test "invalid input" do
+    assert ResourceParser.call(%{id: "123"}, fn resource ->
+      assert %{id: _} = resource
+
+      {:error, :invalid_pointers, [id: "id"]}
+    end) == {:error, [id: "id"]}
+  end
+end


### PR DESCRIPTION
In this PR I'm adding similar parser to `Surgex.Parser.ResourceArrayParser` called `Surgex.Parser.ResourceParser` that is responsible for parsing single instance of resource.