### PR TITLE
Add optional range of acceptable values for `Surgex.Parser.FloatParser`.

### DIFF
--- a/lib/surgex/parser/parsers/float_parser.ex
+++ b/lib/surgex/parser/parsers/float_parser.ex
@@ -1,13 +1,26 @@
 defmodule Surgex.Parser.FloatParser do
   @moduledoc false
 
-  def call(nil), do: {:ok, nil}
-  def call(input) when is_binary(input) do
+  def call(input, opts \\ [])
+  def call(nil, _opts), do: {:ok, nil}
+  def call(input, opts) when is_binary(input) do
+    min = Keyword.get(opts, :min)
+    max = Keyword.get(opts, :max)
+
     case Float.parse(input) do
       {float, ""} ->
-        {:ok, float}
+        validate_range(float, min, max)
       _ ->
         {:error, :invalid_float}
+    end
+  end
+
+  defp validate_range(input, min, max) do
+    case input do
+      float when (is_number(min) and float < min) or (is_number(max) and float > max) ->
+        {:error, :out_of_range}
+      float ->
+        {:ok, float}
     end
   end
 end

--- a/test/surgex/parser/parsers/float_parser_test.exs
+++ b/test/surgex/parser/parsers/float_parser_test.exs
@@ -9,11 +9,14 @@ defmodule Surgex.Parser.FloatParserTest do
   test "valid input" do
     assert FloatParser.call("1") == {:ok, 1.0}
     assert FloatParser.call("1.5") == {:ok, 1.5}
+    assert FloatParser.call("1.5", min: 1.5, max: 1.5) == {:ok, 1.5}
   end
 
   test "invalid input" do
     assert FloatParser.call("1.3a") == {:error, :invalid_float}
     assert FloatParser.call("x") == {:error, :invalid_float}
     assert FloatParser.call("") == {:error, :invalid_float}
+    assert FloatParser.call("1.5", min: 1.6) == {:error, :out_of_range}
+    assert FloatParser.call("1.5", max: 1.4) == {:error, :out_of_range}
   end
 end


### PR DESCRIPTION
Adds optional range of acceptable values for `Surgex.Parser.FloatParser`, similar to `Surgex.Parser.IntegerParser`