### PR TITLE
Extend `Surgex.Parser.BooleanParser` to take Boolean as an input

### DIFF
--- a/lib/surgex/parser/parsers/boolean_parser.ex
+++ b/lib/surgex/parser/parsers/boolean_parser.ex
@@ -4,5 +4,7 @@ defmodule Surgex.Parser.BooleanParser do
   def call(nil), do: {:ok, nil}
   def call("0"), do: {:ok, false}
   def call("1"), do: {:ok, true}
+  def call(false), do: {:ok, false}
+  def call(true), do: {:ok, true}
   def call(_input), do: {:error, :invalid_boolean}
 end

--- a/test/surgex/parser/parsers/boolean_parser_test.exs
+++ b/test/surgex/parser/parsers/boolean_parser_test.exs
@@ -9,6 +9,8 @@ defmodule Surgex.Parser.BooleanParserTest do
   test "valid input" do
     assert BooleanParser.call("0") == {:ok, false}
     assert BooleanParser.call("1") == {:ok, true}
+    assert BooleanParser.call(false) == {:ok, false}
+    assert BooleanParser.call(true) == {:ok, true}
   end
 
   test "invalid input" do


### PR DESCRIPTION
Now Surgex.Parser.BooleanParser takes only string as an input.
In this PR I extend it to handle boolean input as well.