### PR TITLE
Extend FloatParser to take integer as an input

### DIFF
--- a/lib/surgex/parser/parsers/float_parser.ex
+++ b/lib/surgex/parser/parsers/float_parser.ex
@@ -3,6 +3,9 @@ defmodule Surgex.Parser.FloatParser do
 
   def call(input, opts \\ [])
   def call(nil, _opts), do: {:ok, nil}
+  def call(input, opts) when is_integer(input) do
+    call(input / 1, opts)
+  end
   def call(input, opts) when is_float(input) do
     min = Keyword.get(opts, :min)
     max = Keyword.get(opts, :max)

--- a/test/surgex/parser/parsers/float_parser_test.exs
+++ b/test/surgex/parser/parsers/float_parser_test.exs
@@ -7,6 +7,8 @@ defmodule Surgex.Parser.FloatParserTest do
   end
 
   test "valid input" do
+    assert FloatParser.call(2) == {:ok, 2.0}
+    assert FloatParser.call(1, min: 0.9, max: 1.1) == {:ok, 1.0}
     assert FloatParser.call(12.34) == {:ok, 12.34}
     assert FloatParser.call("1") == {:ok, 1.0}
     assert FloatParser.call("1.5") == {:ok, 1.5}
@@ -17,6 +19,7 @@ defmodule Surgex.Parser.FloatParserTest do
     assert FloatParser.call("1.3a") == {:error, :invalid_float}
     assert FloatParser.call("x") == {:error, :invalid_float}
     assert FloatParser.call("") == {:error, :invalid_float}
+    assert FloatParser.call(2, min: 0.9, max: 1.1) == {:error, :out_of_range}
     assert FloatParser.call("1.5", min: 1.6) == {:error, :out_of_range}
     assert FloatParser.call("1.5", max: 1.4) == {:error, :out_of_range}
   end


### PR DESCRIPTION
Since from JS standpoint there is only one type for both integers and floats parser should be able to accept any JSON number as float.