### PR TITLE
Add `allow_empty` option to `Surgex.Parser.StringParser`

### DIFF
--- a/lib/surgex/parser/parsers/string_parser.ex
+++ b/lib/surgex/parser/parsers/string_parser.ex
@@ -1,7 +1,9 @@
 defmodule Surgex.Parser.StringParser do
   @moduledoc false
 
-  def call(nil), do: {:ok, nil}
-  def call(""), do: {:ok, nil}
-  def call(input) when is_binary(input), do: {:ok, input}
+  def call(input, opts \\ [])
+  def call(nil, _opts), do: {:ok, nil}
+  def call("", :allow_empty), do: {:ok, ""}
+  def call("", _opts), do: {:ok, nil}
+  def call(input, _opts) when is_binary(input), do: {:ok, input}
 end

--- a/test/surgex/parser/parser_test.exs
+++ b/test/surgex/parser/parser_test.exs
@@ -12,6 +12,7 @@ defmodule Surgex.ParserTest do
     last_name: :string,
     phone: :string,
     include: [{:include, [:comments]}, :required],
+    address: [{:string, :allow_empty}]
   ]
 
   @valid_params %{
@@ -20,7 +21,8 @@ defmodule Surgex.ParserTest do
     "price" => "10.5",
     "first-name" => "Jack",
     "last-name" => "",
-    "include" => "comments"
+    "include" => "comments",
+    "address" => ""
   }
 
   @invalid_params %{
@@ -82,6 +84,7 @@ defmodule Surgex.ParserTest do
       parser_output = Parser.parse @valid_params, @param_parsers
 
       assert parser_output == {:ok, [
+        address: "",
         include: [:comments],
         last_name: nil,
         first_name: "Jack",
@@ -234,7 +237,7 @@ defmodule Surgex.ParserTest do
     test "valid params" do
       parser_output = Parser.flat_parse @valid_params, @param_parsers
 
-      assert parser_output == {:ok, 123, "asdf", 10.5, "Jack", nil, nil, [:comments]}
+      assert parser_output == {:ok, 123, "asdf", 10.5, "Jack", nil, nil, [:comments], ""}
     end
 
     test "invalid params" do

--- a/test/surgex/parser/parsers/string_parser_test.exs
+++ b/test/surgex/parser/parsers/string_parser_test.exs
@@ -8,6 +8,7 @@ defmodule Surgex.Parser.StringParserTest do
 
   test "valid input" do
     assert StringParser.call("") == {:ok, nil}
+    assert StringParser.call("", :allow_empty) == {:ok, ""}
     assert StringParser.call("abc") == {:ok, "abc"}
   end
 end


### PR DESCRIPTION
Currently `Surgex.Parser.StringParser` replaces `""` with `nil`, but sometimes it might be useful to keep the original value


