### PR TITLE
Add list handling for id_list parser

### DIFF
--- a/lib/surgex/parser/parsers/id_list_parser.ex
+++ b/lib/surgex/parser/parsers/id_list_parser.ex
@@ -11,7 +11,14 @@ defmodule Surgex.Parser.IdListParser do
     input
     |> String.split(",")
     |> Enum.reduce({:ok, []}, &reduce_ids/2)
-    |> reverse
+    |> reverse()
+    |> check_max(Keyword.get(opts, :max))
+  end
+
+  def call(input, opts) when is_list(input) do
+    input
+    |> Enum.reduce({:ok, []}, &reduce_ids/2)
+    |> reverse()
     |> check_max(Keyword.get(opts, :max))
   end
 
@@ -19,7 +26,7 @@ defmodule Surgex.Parser.IdListParser do
     {:error, reason}
   end
 
-  defp reduce_ids(id_string, {:ok, previous_ids}) do
+  defp reduce_ids(id_string, {:ok, previous_ids}) when is_binary(id_string) do
     case IdParser.call(id_string) do
       {:ok, id} ->
         {:ok, [id | previous_ids]}
@@ -27,6 +34,14 @@ defmodule Surgex.Parser.IdListParser do
       {:error, reason} ->
         {:error, reason}
     end
+  end
+
+  defp reduce_ids(id, {:ok, previous_ids}) when is_integer(id) and id > 0 do
+    {:ok, [id | previous_ids]}
+  end
+
+  defp reduce_ids(id, {:ok, _previous_ids}) when is_integer(id) do
+    {:error, :invalid_identifier}
   end
 
   defp reverse({:ok, ids}), do: {:ok, Enum.reverse(ids)}

--- a/test/surgex/parser/parsers/id_list_parser_test.exs
+++ b/test/surgex/parser/parsers/id_list_parser_test.exs
@@ -11,6 +11,10 @@ defmodule Surgex.Parser.IdListParserTest do
     assert IdListParser.call("123") == {:ok, [123]}
     assert IdListParser.call("123,456") == {:ok, [123, 456]}
     assert IdListParser.call("123,456", max: 2) == {:ok, [123, 456]}
+
+    assert IdListParser.call([]) == {:ok, []}
+    assert IdListParser.call([1, 2, 3]) == {:ok, [1, 2, 3]}
+    assert IdListParser.call(["1", "2", "3"]) == {:ok, [1, 2, 3]}
   end
 
   test "invalid input" do
@@ -18,5 +22,8 @@ defmodule Surgex.Parser.IdListParserTest do
     assert IdListParser.call("123,abc") == {:error, :invalid_integer}
     assert IdListParser.call("abc") == {:error, :invalid_integer}
     assert IdListParser.call("123,456,789", max: 2) == {:error, :invalid_id_list_length}
+    assert IdListParser.call(["1", "2", "three"]) == {:error, :invalid_integer}
+    assert IdListParser.call([1, -2, 3]) == {:error, :invalid_identifier}
+    assert IdListParser.call(["1", "-2", "3"]) == {:error, :invalid_identifier}
   end
 end


### PR DESCRIPTION
Extend ability of our id_list parser to be capable of handling list types containing either strings or integer values.