### PR TITLE
Fix email regex

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -29,6 +29,7 @@ if Mix.env() == :test do
     adapter: Ecto.Adapters.Postgres,
     database: "surgex_repo_test",
     hostname: "localhost",
+    username: "postgres",
     pool: Ecto.Adapters.SQL.Sandbox,
     port: System.get_env("POSTGRES_TEST_PORT")
 
@@ -36,6 +37,7 @@ if Mix.env() == :test do
     adapter: Ecto.Adapters.Postgres,
     database: "surgex_foreign_repo_test",
     hostname: "localhost",
+    username: "postgres",
     pool: Ecto.Adapters.SQL.Sandbox,
     port: System.get_env("POSTGRES_TEST_PORT")
 end

--- a/lib/surgex/parser/parsers/email_parser.ex
+++ b/lib/surgex/parser/parsers/email_parser.ex
@@ -1,7 +1,7 @@
 defmodule Surgex.Parser.EmailParser do
   @moduledoc false
 
-  @email_regex ~r/^([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+$/i
+  @email_regex ~r/^([\w+\-]\.?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+$/i
 
   def call(nil), do: {:ok, nil}
 

--- a/test/surgex/parser/parsers/email_parser_test.exs
+++ b/test/surgex/parser/parsers/email_parser_test.exs
@@ -8,11 +8,13 @@ defmodule Surgex.Parser.EmailParserTest do
 
   test "valid input" do
     assert EmailParser.call("me@example.com") == {:ok, "me@example.com"}
+    assert EmailParser.call("qwert@qwertyuiop.asdfghjklasdfghasssjkl.com") == {:ok, "qwert@qwertyuiop.asdfghjklasdfghasssjkl.com"}
   end
 
   test "invalid input" do
     assert EmailParser.call("me") == {:error, :invalid_email}
     assert EmailParser.call("me@example") == {:error, :invalid_email}
     assert EmailParser.call("example.com") == {:error, :invalid_email}
+    assert EmailParser.call("a@b@c@d@example.com") == {:error, :invalid_email}
   end
 end


### PR DESCRIPTION
## Overview
This pull request fixes email parser regex.

The reason of the regex not working properly is missing escape sign for `.` in the first group.

When `.` is not escaped, regex allows for matching `a@b@c@d@example.com` as the dot consumes the `@` characters.

Unescaped `.` is also a problem for some of the appropriate email addresses like `qwert@qwertyuiop.asdfghjklasdfghasssjkl.com`. This one fails due to catastrophic backtracking - regex engine needs to backtrack too many times in order to be able to tell whether the string matches or not. It can be well seen on regex debugger, that this email address is at first matched only with `([\w+\-].?)` groups, and then backtracks plenty of times. The reason for this is that `@` is consumed by `.` not by `@` from regex.