### PR TITLE
Improve regexp for email parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
+## 3.2.7
+
+- Simplified email regex to fix catastrophic backtracing error when providing longer addresses
+
 ## 3.2.6
 
 - Added ssl in `Surgex.RepoHelpers`
-
 
 ## 3.2.5
 

--- a/lib/surgex/parser/parsers/email_parser.ex
+++ b/lib/surgex/parser/parsers/email_parser.ex
@@ -1,7 +1,7 @@
 defmodule Surgex.Parser.EmailParser do
   @moduledoc false
 
-  @email_regex ~r/^([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+$/i
+  @email_regex ~r/^[^@\s]+@[^@\s]+\.[^@\s]+$/i
 
   @spec call(nil) :: {:ok, nil}
   @spec call(String.t()) :: {:ok, String.t()} | {:error, :invalid_email}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Surgex.Mixfile do
   def project do
     [
       app: :surgex,
-      version: "3.2.6",
+      version: "3.2.7",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,

--- a/test/surgex/parser/parsers/email_parser_test.exs
+++ b/test/surgex/parser/parsers/email_parser_test.exs
@@ -7,12 +7,26 @@ defmodule Surgex.Parser.EmailParserTest do
   end
 
   test "valid input" do
-    assert EmailParser.call("me@example.com") == {:ok, "me@example.com"}
+    valid_emails =
+      [
+        "me@example.com",
+        "example@superlongdomainloremipsumdolor.co.uk",
+        "mailhost!username@example.org",
+        "me+you@gmail.com",
+        "other.email-with-hyphen@example.com",
+        "\".John.Doe\"@example.com",
+        "user%example.com@example.org"
+      ]
+      |> Enum.each(fn email ->
+        assert EmailParser.call(email) == {:ok, email}
+      end)
   end
 
   test "invalid input" do
     assert EmailParser.call("me") == {:error, :invalid_email}
     assert EmailParser.call("me@example") == {:error, :invalid_email}
     assert EmailParser.call("example.com") == {:error, :invalid_email}
+    assert EmailParser.call("he llo@example.com") == {:error, :invalid_email}
+    assert EmailParser.call("me@example@gmail.com") == {:error, :invalid_email}
   end
 end


### PR DESCRIPTION
Backstory:
- noticed that current regexp fails for long emails due to catastrophic backtracking (f.e. `example@superlongdomainloremipsumdolor.co.uk`)
- find out that someone else fixed problem: https://github.com/surgeventures/surgex/pull/18
- run check on our big database to check if new regexp is backwards compatible and find out it is not
- learn about quirks of emails from wikipedia: https://en.wikipedia.org/wiki/Email_address#RFC_specification
- decide that very strict checking is not the best idea:
  - lot of edge cases with special characters
  - this parser can be used f.e. on login/password reset and we don't want to prevent anyone from accessing account because of validation

This PR contains simpler and yet backwards compatible regexp which still checks basic misspelling of emails (multiple @, missing domain or whitespaces). Also this regexp fixes initial problem with failing when longer email is provided.