### PR TITLE
Fix typespec for flat_parse

### DIFF
--- a/lib/surgex/parser/parser.ex
+++ b/lib/surgex/parser/parser.ex
@@ -85,6 +85,7 @@ defmodule Surgex.Parser do
   tuple instead of a `[key1: value1, key2: value2, ...]` keyword list.
   """
   @spec flat_parse(nil, any) :: {:error, :empty_input}
+  # any number of params could be parsed, so the best spec for {:ok, v1, v2, vn} is tuple()
   @spec flat_parse(map, list) ::
           tuple() | {:error, :invalid_parameters, list} | {:error, :invalid_pointers, list}
   def flat_parse(input, parsers)

--- a/lib/surgex/parser/parser.ex
+++ b/lib/surgex/parser/parser.ex
@@ -86,7 +86,7 @@ defmodule Surgex.Parser do
   """
   @spec flat_parse(nil, any) :: {:error, :empty_input}
   @spec flat_parse(map, list) ::
-          {:ok, any} | {:error, :invalid_parameters, list} | {:error, :invalid_pointers, list}
+          tuple() | {:error, :invalid_parameters, list} | {:error, :invalid_pointers, list}
   def flat_parse(input, parsers)
 
   def flat_parse(doc = %{__struct__: Jabbax.Document}, parsers) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Surgex.Mixfile do
   def project do
     [
       app: :surgex,
-      version: "4.1.0",
+      version: "4.1.1",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
When using to parse more than one param, for example:
```
flat_parse(
      params,
      id: [:id, :required],
      include: {:include, [:"customer-payment-method"]}
    )
```

Dialyzer returned error:

 ```
    The pattern can never match the type.

Pattern:
{:ok, _customer_id, _includes}

Type:

  {:error, :empty_input}
  | {:ok, _}
  | {:error, :invalid_parameters | :invalid_pointers, [any()]}
```

I could not find any better spec definition to describe tuple with `:ok` and then one or more terms



https://github.com/elixir-lang/elixir/issues/3924
    