### PR TITLE
Handle all possible JSON values in the parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.3.0
+
+- Parsers can now process any valid JSON value without throwing exception on unknown value type
+
 ## 4.2.0
 
 - Added support for translating errors in nested changeset to JSON API responses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 4.3.0
+## 4.2.1
 
-- Parsers can now process any valid JSON value without throwing exception on unknown value type
+- Parsers can now process any value without throwing exception on unknown value type
 
 ## 4.2.0
 

--- a/lib/surgex/parser/parsers/boolean_parser.ex
+++ b/lib/surgex/parser/parsers/boolean_parser.ex
@@ -1,7 +1,7 @@
 defmodule Surgex.Parser.BooleanParser do
   @moduledoc false
 
-  @spec call(Surgex.Types.json_value()) :: {:ok, true | false} | {:error, :invalid_boolean}
+  @spec call(term()) :: {:ok, boolean()} | {:error, :invalid_boolean}
   def call(nil), do: {:ok, nil}
   def call("0"), do: {:ok, false}
   def call("1"), do: {:ok, true}

--- a/lib/surgex/parser/parsers/boolean_parser.ex
+++ b/lib/surgex/parser/parsers/boolean_parser.ex
@@ -1,7 +1,7 @@
 defmodule Surgex.Parser.BooleanParser do
   @moduledoc false
 
-  @spec call(term()) :: {:ok, boolean()} | {:error, :invalid_boolean}
+  @spec call(term()) :: {:ok, boolean() | nil} | {:error, :invalid_boolean}
   def call(nil), do: {:ok, nil}
   def call("0"), do: {:ok, false}
   def call("1"), do: {:ok, true}

--- a/lib/surgex/parser/parsers/boolean_parser.ex
+++ b/lib/surgex/parser/parsers/boolean_parser.ex
@@ -1,7 +1,7 @@
 defmodule Surgex.Parser.BooleanParser do
   @moduledoc false
 
-  @spec call(any) :: {:ok, true | false} | {:error, :invalid_boolean}
+  @spec call(Surgex.Types.json_value()) :: {:ok, true | false} | {:error, :invalid_boolean}
   def call(nil), do: {:ok, nil}
   def call("0"), do: {:ok, false}
   def call("1"), do: {:ok, true}

--- a/lib/surgex/parser/parsers/boolean_parser.ex
+++ b/lib/surgex/parser/parsers/boolean_parser.ex
@@ -1,10 +1,7 @@
 defmodule Surgex.Parser.BooleanParser do
   @moduledoc false
 
-  @spec call(nil) :: {:ok, nil}
-  @spec call(true) :: {:ok, true}
-  @spec call(false) :: {:ok, false}
-  @spec call(String.t()) :: {:ok, true | false} | {:error, :invalid_boolean}
+  @spec call(any) :: {:ok, true | false} | {:error, :invalid_boolean}
   def call(nil), do: {:ok, nil}
   def call("0"), do: {:ok, false}
   def call("1"), do: {:ok, true}

--- a/lib/surgex/parser/parsers/contain_parser.ex
+++ b/lib/surgex/parser/parsers/contain_parser.ex
@@ -4,7 +4,7 @@ defmodule Surgex.Parser.ContainParser do
   """
 
   @doc false
-  @spec call(nil, any) :: {:ok, nil} | {:ok, any} | {:error, :invalid_value}
+  @spec call(nil, term()) :: {:ok, term() | nil} | {:error, :invalid_value}
   def call(nil, _allowed_values), do: {:ok, nil}
 
   def call(input, allowed_values) when is_list(allowed_values) do

--- a/lib/surgex/parser/parsers/contain_parser.ex
+++ b/lib/surgex/parser/parsers/contain_parser.ex
@@ -4,7 +4,7 @@ defmodule Surgex.Parser.ContainParser do
   """
 
   @doc false
-  @spec call(nil, term()) :: {:ok, term() | nil} | {:error, :invalid_value}
+  @spec call(term(), nonempty_list()) :: {:ok, term() | nil} | {:error, :invalid_value}
   def call(nil, _allowed_values), do: {:ok, nil}
 
   def call(input, allowed_values) when is_list(allowed_values) do

--- a/lib/surgex/parser/parsers/date_parser.ex
+++ b/lib/surgex/parser/parsers/date_parser.ex
@@ -1,8 +1,7 @@
 defmodule Surgex.Parser.DateParser do
   @moduledoc false
 
-  @spec call(nil) :: {:ok, nil}
-  @spec call(String.t()) :: {:ok, Date.t()} | {:ok, :invalid_date}
+  @spec call(any) :: {:ok, nil} | {:ok, Date.t()} | {:ok, :invalid_date}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do
@@ -14,4 +13,6 @@ defmodule Surgex.Parser.DateParser do
         {:error, :invalid_date}
     end
   end
+
+  def call(_input), do: {:error, :invalid_date}
 end

--- a/lib/surgex/parser/parsers/date_parser.ex
+++ b/lib/surgex/parser/parsers/date_parser.ex
@@ -1,7 +1,7 @@
 defmodule Surgex.Parser.DateParser do
   @moduledoc false
 
-  @spec call(Surgex.Types.json_value()) :: {:ok, Date.t() | nil} | {:ok, :invalid_date}
+  @spec call(term()) :: {:ok, Date.t() | nil} | {:error, :invalid_date}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do

--- a/lib/surgex/parser/parsers/date_parser.ex
+++ b/lib/surgex/parser/parsers/date_parser.ex
@@ -1,7 +1,7 @@
 defmodule Surgex.Parser.DateParser do
   @moduledoc false
 
-  @spec call(Surgex.Types.json_value()) :: {:ok, nil} | {:ok, Date.t()} | {:ok, :invalid_date}
+  @spec call(Surgex.Types.json_value()) :: {:ok, Date.t() | nil} | {:ok, :invalid_date}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do

--- a/lib/surgex/parser/parsers/date_parser.ex
+++ b/lib/surgex/parser/parsers/date_parser.ex
@@ -1,7 +1,7 @@
 defmodule Surgex.Parser.DateParser do
   @moduledoc false
 
-  @spec call(any) :: {:ok, nil} | {:ok, Date.t()} | {:ok, :invalid_date}
+  @spec call(Surgex.Types.json_value()) :: {:ok, nil} | {:ok, Date.t()} | {:ok, :invalid_date}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do

--- a/lib/surgex/parser/parsers/email_parser.ex
+++ b/lib/surgex/parser/parsers/email_parser.ex
@@ -3,8 +3,7 @@ defmodule Surgex.Parser.EmailParser do
 
   @email_regex ~r/^[^@\s]+@[^@\s]+\.[^@\s]+$/i
 
-  @spec call(nil) :: {:ok, nil}
-  @spec call(String.t()) :: {:ok, String.t()} | {:error, :invalid_email}
+  @spec call(any) :: {:ok, nil} | {:ok, String.t()} | {:error, :invalid_email}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do
@@ -14,4 +13,6 @@ defmodule Surgex.Parser.EmailParser do
       {:error, :invalid_email}
     end
   end
+
+  def call(_input), do: {:error, :invalid_email}
 end

--- a/lib/surgex/parser/parsers/email_parser.ex
+++ b/lib/surgex/parser/parsers/email_parser.ex
@@ -3,7 +3,7 @@ defmodule Surgex.Parser.EmailParser do
 
   @email_regex ~r/^[^@\s]+@[^@\s]+\.[^@\s]+$/i
 
-  @spec call(Surgex.Types.json_value()) :: {:ok, nil} | {:ok, String.t()} | {:error, :invalid_email}
+  @spec call(Surgex.Types.json_value()) :: {:ok, String.t() | nil} | {:error, :invalid_email}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do

--- a/lib/surgex/parser/parsers/email_parser.ex
+++ b/lib/surgex/parser/parsers/email_parser.ex
@@ -3,7 +3,7 @@ defmodule Surgex.Parser.EmailParser do
 
   @email_regex ~r/^[^@\s]+@[^@\s]+\.[^@\s]+$/i
 
-  @spec call(any) :: {:ok, nil} | {:ok, String.t()} | {:error, :invalid_email}
+  @spec call(Surgex.Types.json_value()) :: {:ok, nil} | {:ok, String.t()} | {:error, :invalid_email}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do

--- a/lib/surgex/parser/parsers/email_parser.ex
+++ b/lib/surgex/parser/parsers/email_parser.ex
@@ -3,7 +3,7 @@ defmodule Surgex.Parser.EmailParser do
 
   @email_regex ~r/^[^@\s]+@[^@\s]+\.[^@\s]+$/i
 
-  @spec call(Surgex.Types.json_value()) :: {:ok, String.t() | nil} | {:error, :invalid_email}
+  @spec call(term()) :: {:ok, String.t() | nil} | {:error, :invalid_email}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do

--- a/lib/surgex/parser/parsers/float_parser.ex
+++ b/lib/surgex/parser/parsers/float_parser.ex
@@ -2,7 +2,7 @@ defmodule Surgex.Parser.FloatParser do
   @moduledoc false
   @type errors :: :invalid_float | :out_of_range
 
-  @spec call(any, list) :: {:ok, nil} | {:ok, float} | {:error, errors}
+  @spec call(Surgex.Types.json_value(), list) :: {:ok, nil} | {:ok, float} | {:error, errors}
   def call(input, opts \\ [])
   def call(nil, _opts), do: {:ok, nil}
 

--- a/lib/surgex/parser/parsers/float_parser.ex
+++ b/lib/surgex/parser/parsers/float_parser.ex
@@ -1,8 +1,9 @@
 defmodule Surgex.Parser.FloatParser do
   @moduledoc false
   @type errors :: :invalid_float | :out_of_range
+  @type option :: {:min, number()} | {:max, number()}
 
-  @spec call(term(), list) :: {:ok, float | nil} | {:error, errors}
+  @spec call(term(), [option()]) :: {:ok, float() | nil} | {:error, errors()}
   def call(input, opts \\ [])
   def call(nil, _opts), do: {:ok, nil}
 

--- a/lib/surgex/parser/parsers/float_parser.ex
+++ b/lib/surgex/parser/parsers/float_parser.ex
@@ -2,8 +2,7 @@ defmodule Surgex.Parser.FloatParser do
   @moduledoc false
   @type errors :: :invalid_float | :out_of_range
 
-  @spec call(nil, any) :: {:ok, nil}
-  @spec call(number | String.t(), list) :: {:ok, float} | {:error, errors}
+  @spec call(any, list) :: {:ok, nil} | {:ok, float} | {:error, errors}
   def call(input, opts \\ [])
   def call(nil, _opts), do: {:ok, nil}
 
@@ -30,6 +29,8 @@ defmodule Surgex.Parser.FloatParser do
         {:error, :invalid_float}
     end
   end
+
+  def call(_input, _opts), do: {:error, :invalid_float}
 
   defp validate_range(input, min, max) do
     case input do

--- a/lib/surgex/parser/parsers/float_parser.ex
+++ b/lib/surgex/parser/parsers/float_parser.ex
@@ -2,7 +2,7 @@ defmodule Surgex.Parser.FloatParser do
   @moduledoc false
   @type errors :: :invalid_float | :out_of_range
 
-  @spec call(Surgex.Types.json_value(), list) :: {:ok, nil} | {:ok, float} | {:error, errors}
+  @spec call(Surgex.Types.json_value(), list) :: {:ok, float | nil} | {:error, errors}
   def call(input, opts \\ [])
   def call(nil, _opts), do: {:ok, nil}
 

--- a/lib/surgex/parser/parsers/float_parser.ex
+++ b/lib/surgex/parser/parsers/float_parser.ex
@@ -2,7 +2,7 @@ defmodule Surgex.Parser.FloatParser do
   @moduledoc false
   @type errors :: :invalid_float | :out_of_range
 
-  @spec call(Surgex.Types.json_value(), list) :: {:ok, float | nil} | {:error, errors}
+  @spec call(term(), list) :: {:ok, float | nil} | {:error, errors}
   def call(input, opts \\ [])
   def call(nil, _opts), do: {:ok, nil}
 

--- a/lib/surgex/parser/parsers/geobox_parser.ex
+++ b/lib/surgex/parser/parsers/geobox_parser.ex
@@ -5,8 +5,7 @@ defmodule Surgex.Parser.GeoboxParser do
 
   @type errors :: :invalid_geobox_tuple | :invalid_geobox
 
-  @spec call(nil) :: {:ok, nil}
-  @spec call(String.t()) :: {:ok, Geobox.t()} | {:error, errors}
+  @spec call(term()) :: {:ok, Geobox.t() | nil} | {:error, errors}
   def call(nil), do: {:ok, nil}
 
   # credo:disable-for-next-line Credo.Check.Refactor.ABCSize

--- a/lib/surgex/parser/parsers/geobox_parser.ex
+++ b/lib/surgex/parser/parsers/geobox_parser.ex
@@ -23,6 +23,8 @@ defmodule Surgex.Parser.GeoboxParser do
     end
   end
 
+  def call(_input), do: {:error, :invalid_geobox_tuple}
+
   defp valid_box?(north_east, south_west) do
     north_east.latitude - south_west.latitude > 0
   end

--- a/lib/surgex/parser/parsers/geolocation_parser.ex
+++ b/lib/surgex/parser/parsers/geolocation_parser.ex
@@ -26,6 +26,8 @@ defmodule Surgex.Parser.GeolocationParser do
     parse_lat_lng_strings(lat_string, lng_string)
   end
 
+  def call(_input), do: {:error, :invalid_geolocation_tuple}
+
   defp parse_lat_lng_strings(lat_string, lng_string) do
     with {:ok, lat} <- FloatParser.call(lat_string),
          {:ok, lng} <- FloatParser.call(lng_string),

--- a/lib/surgex/parser/parsers/geolocation_parser.ex
+++ b/lib/surgex/parser/parsers/geolocation_parser.ex
@@ -3,13 +3,9 @@ defmodule Surgex.Parser.GeolocationParser do
 
   alias Surgex.Parser.{FloatParser, Geolocation}
 
-  @type errors :: :invalid_geolocation_tuple | :invalid_geolocation
+  @type errors :: :invalid_geolocation_tuple | :invalid_geolocation | FloatParser.errors()
 
-  @spec call(nil) :: {:ok, nil}
-  @spec call(String.t()) ::
-          {:ok, Geolocation.t()} | {:error, errors} | {:error, FloatParser.errors()}
-  @spec call({String.t(), String.t()}) ::
-          {:ok, Geolocation.t()} | {:error, errors} | {:error, FloatParser.errors()}
+  @spec call(term()) :: {:ok, Geolocation.t()} | {:error, errors}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do

--- a/lib/surgex/parser/parsers/geolocation_parser.ex
+++ b/lib/surgex/parser/parsers/geolocation_parser.ex
@@ -5,7 +5,7 @@ defmodule Surgex.Parser.GeolocationParser do
 
   @type errors :: :invalid_geolocation_tuple | :invalid_geolocation | FloatParser.errors()
 
-  @spec call(term()) :: {:ok, Geolocation.t()} | {:error, errors}
+  @spec call(term()) :: {:ok, Geolocation.t() | nil} | {:error, errors()}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do

--- a/lib/surgex/parser/parsers/id_list_parser.ex
+++ b/lib/surgex/parser/parsers/id_list_parser.ex
@@ -5,7 +5,7 @@ defmodule Surgex.Parser.IdListParser do
 
   @type errors :: :invalid_identifier | :invalid_id_list_length | IdParser.errors()
 
-  @spec call(Surgex.Types.json_value(), Keyword.t()) :: {:ok, [integer]} | {:error, errors}
+  @spec call(term(), Keyword.t()) :: {:ok, [integer]} | {:error, errors}
   def call(input, opts \\ [])
   def call(nil, _opts), do: {:ok, []}
   def call("", _opts), do: {:ok, []}

--- a/lib/surgex/parser/parsers/id_list_parser.ex
+++ b/lib/surgex/parser/parsers/id_list_parser.ex
@@ -5,7 +5,7 @@ defmodule Surgex.Parser.IdListParser do
 
   @type errors :: :invalid_identifier | :invalid_id_list_length | IdParser.errors()
 
-  @spec call(String.t() | List.t() | nil, Keyword.t()) :: {:ok, [integer]} | {:error, errors}
+  @spec call(any, Keyword.t()) :: {:ok, [integer]} | {:error, errors}
   def call(input, opts \\ [])
   def call(nil, _opts), do: {:ok, []}
   def call("", _opts), do: {:ok, []}
@@ -24,6 +24,8 @@ defmodule Surgex.Parser.IdListParser do
     |> reverse()
     |> check_max(Keyword.get(opts, :max))
   end
+
+  def call(_input, _opts), do: {:error, :invalid_id_list}
 
   defp reduce_ids(_, {:error, reason}) do
     {:error, reason}

--- a/lib/surgex/parser/parsers/id_list_parser.ex
+++ b/lib/surgex/parser/parsers/id_list_parser.ex
@@ -4,8 +4,9 @@ defmodule Surgex.Parser.IdListParser do
   alias Surgex.Parser.IdParser
 
   @type errors :: :invalid_identifier | :invalid_id_list_length | IdParser.errors()
+  @type option :: {:max, integer()}
 
-  @spec call(term(), Keyword.t()) :: {:ok, [integer]} | {:error, errors}
+  @spec call(term(), [option()]) :: {:ok, [integer()]} | {:error, errors()}
   def call(input, opts \\ [])
   def call(nil, _opts), do: {:ok, []}
   def call("", _opts), do: {:ok, []}

--- a/lib/surgex/parser/parsers/id_list_parser.ex
+++ b/lib/surgex/parser/parsers/id_list_parser.ex
@@ -5,7 +5,7 @@ defmodule Surgex.Parser.IdListParser do
 
   @type errors :: :invalid_identifier | :invalid_id_list_length | IdParser.errors()
 
-  @spec call(any, Keyword.t()) :: {:ok, [integer]} | {:error, errors}
+  @spec call(Surgex.Types.json_value(), Keyword.t()) :: {:ok, [integer]} | {:error, errors}
   def call(input, opts \\ [])
   def call(nil, _opts), do: {:ok, []}
   def call("", _opts), do: {:ok, []}

--- a/lib/surgex/parser/parsers/id_parser.ex
+++ b/lib/surgex/parser/parsers/id_parser.ex
@@ -5,7 +5,7 @@ defmodule Surgex.Parser.IdParser do
 
   @type errors :: :invalid_identifier | IntegerParser.errors()
 
-  @spec call(Surgex.Types.json_value()) :: {:ok, integer | nil} | {:error, errors}
+  @spec call(term()) :: {:ok, integer | nil} | {:error, errors}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do

--- a/lib/surgex/parser/parsers/id_parser.ex
+++ b/lib/surgex/parser/parsers/id_parser.ex
@@ -5,7 +5,7 @@ defmodule Surgex.Parser.IdParser do
 
   @type errors :: :invalid_identifier | IntegerParser.errors()
 
-  @spec call(Surgex.Types.json_value()) :: {:ok, nil} | {:ok, integer} | {:error, errors}
+  @spec call(Surgex.Types.json_value()) :: {:ok, integer | nil} | {:error, errors}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do

--- a/lib/surgex/parser/parsers/id_parser.ex
+++ b/lib/surgex/parser/parsers/id_parser.ex
@@ -5,7 +5,7 @@ defmodule Surgex.Parser.IdParser do
 
   @type errors :: :invalid_identifier | IntegerParser.errors()
 
-  @spec call(any) :: {:ok, nil} | {:ok, integer} | {:error, errors}
+  @spec call(Surgex.Types.json_value()) :: {:ok, nil} | {:ok, integer} | {:error, errors}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do

--- a/lib/surgex/parser/parsers/id_parser.ex
+++ b/lib/surgex/parser/parsers/id_parser.ex
@@ -5,8 +5,7 @@ defmodule Surgex.Parser.IdParser do
 
   @type errors :: :invalid_identifier | IntegerParser.errors()
 
-  @spec call(nil) :: {:ok, nil}
-  @spec call(String.t()) :: {:ok, integer} | {:error, errors}
+  @spec call(any) :: {:ok, nil} | {:ok, integer} | {:error, errors}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do
@@ -16,4 +15,6 @@ defmodule Surgex.Parser.IdParser do
       {:error, reason} -> {:error, reason}
     end
   end
+
+  def call(_input), do: {:error, :invalid_identifier}
 end

--- a/lib/surgex/parser/parsers/include_parser.ex
+++ b/lib/surgex/parser/parsers/include_parser.ex
@@ -7,7 +7,8 @@ defmodule Surgex.Parser.IncludeParser do
   """
 
   @doc false
-  @spec call(Surgex.Types.json_value(), []) :: {:ok, [atom]} | {:error, :invalid_relationship_path} | {:error, :invalid_input}
+  @spec call(Surgex.Types.json_value(), []) ::
+          {:ok, [atom]} | {:error, :invalid_relationship_path} | {:error, :invalid_input}
   def call(nil, _spec), do: {:ok, []}
   def call("", _spec), do: {:ok, []}
 

--- a/lib/surgex/parser/parsers/include_parser.ex
+++ b/lib/surgex/parser/parsers/include_parser.ex
@@ -7,7 +7,7 @@ defmodule Surgex.Parser.IncludeParser do
   """
 
   @doc false
-  @spec call(any, []) :: {:ok, [atom]} | {:error, :invalid_relationship_path} | {:error, :invalid_input}
+  @spec call(Surgex.Types.json_value(), []) :: {:ok, [atom]} | {:error, :invalid_relationship_path} | {:error, :invalid_input}
   def call(nil, _spec), do: {:ok, []}
   def call("", _spec), do: {:ok, []}
 

--- a/lib/surgex/parser/parsers/include_parser.ex
+++ b/lib/surgex/parser/parsers/include_parser.ex
@@ -7,8 +7,7 @@ defmodule Surgex.Parser.IncludeParser do
   """
 
   @doc false
-  @spec call(nil, any) :: {:ok, []}
-  @spec call(String.t(), []) :: {:ok, [atom]} | {:error, :invalid_relationship_path}
+  @spec call(any, []) :: {:ok, [atom]} | {:error, :invalid_relationship_path} | {:error, :invalid_input}
   def call(nil, _spec), do: {:ok, []}
   def call("", _spec), do: {:ok, []}
 
@@ -18,6 +17,8 @@ defmodule Surgex.Parser.IncludeParser do
 
     validate_relationship_path(paths, allowed_paths)
   end
+
+  def call(_input, _paths), do: {:error, :invalid_input}
 
   defp convert_to_string(path) when is_binary(path), do: path
   defp convert_to_string(path) when is_atom(path), do: Atom.to_string(path)

--- a/lib/surgex/parser/parsers/include_parser.ex
+++ b/lib/surgex/parser/parsers/include_parser.ex
@@ -7,9 +7,10 @@ defmodule Surgex.Parser.IncludeParser do
   """
 
   @type errors :: :invalid_relationship_path | :invalid_input
+  @type path :: atom() | String.t()
 
   @doc false
-  @spec call(term(), []) :: {:ok, [atom]} | {:error, errors}
+  @spec call(term(), [path()]) :: {:ok, [atom()]} | {:error, errors()}
   def call(nil, _spec), do: {:ok, []}
   def call("", _spec), do: {:ok, []}
 

--- a/lib/surgex/parser/parsers/include_parser.ex
+++ b/lib/surgex/parser/parsers/include_parser.ex
@@ -9,7 +9,7 @@ defmodule Surgex.Parser.IncludeParser do
   @type errors :: :invalid_relationship_path | :invalid_input
 
   @doc false
-  @spec call(Surgex.Types.json_value(), []) :: {:ok, [atom]} | {:error, errors}
+  @spec call(term(), []) :: {:ok, [atom]} | {:error, errors}
   def call(nil, _spec), do: {:ok, []}
   def call("", _spec), do: {:ok, []}
 

--- a/lib/surgex/parser/parsers/include_parser.ex
+++ b/lib/surgex/parser/parsers/include_parser.ex
@@ -6,9 +6,10 @@ defmodule Surgex.Parser.IncludeParser do
   Produces a list of includes constrained to the provided relationship paths.
   """
 
+  @type errors :: :invalid_relationship_path | :invalid_input
+
   @doc false
-  @spec call(Surgex.Types.json_value(), []) ::
-          {:ok, [atom]} | {:error, :invalid_relationship_path} | {:error, :invalid_input}
+  @spec call(Surgex.Types.json_value(), []) :: {:ok, [atom]} | {:error, errors}
   def call(nil, _spec), do: {:ok, []}
   def call("", _spec), do: {:ok, []}
 

--- a/lib/surgex/parser/parsers/integer_parser.ex
+++ b/lib/surgex/parser/parsers/integer_parser.ex
@@ -3,7 +3,7 @@ defmodule Surgex.Parser.IntegerParser do
 
   @type errors :: :invalid_integer | :out_of_range
 
-  @spec call(Surgex.Types.json_value(), list) :: {:ok, integer | nil} | {:error, errors}
+  @spec call(term(), list) :: {:ok, integer | nil} | {:error, errors}
   def call(input, opts \\ [])
   def call(nil, _opts), do: {:ok, nil}
 

--- a/lib/surgex/parser/parsers/integer_parser.ex
+++ b/lib/surgex/parser/parsers/integer_parser.ex
@@ -3,7 +3,7 @@ defmodule Surgex.Parser.IntegerParser do
 
   @type errors :: :invalid_integer | :out_of_range
 
-  @spec call(any, list) :: {:ok, integer | nil} | {:error, errors}
+  @spec call(Surgex.Types.json_value(), list) :: {:ok, integer | nil} | {:error, errors}
   def call(input, opts \\ [])
   def call(nil, _opts), do: {:ok, nil}
 

--- a/lib/surgex/parser/parsers/integer_parser.ex
+++ b/lib/surgex/parser/parsers/integer_parser.ex
@@ -3,8 +3,7 @@ defmodule Surgex.Parser.IntegerParser do
 
   @type errors :: :invalid_integer | :out_of_range
 
-  @spec call(nil, any) :: {:ok, nil}
-  @spec call(String.t() | integer, list) :: {:ok, integer} | {:error, errors}
+  @spec call(any, list) :: {:ok, integer | nil} | {:error, errors}
   def call(input, opts \\ [])
   def call(nil, _opts), do: {:ok, nil}
 
@@ -27,6 +26,8 @@ defmodule Surgex.Parser.IntegerParser do
         {:error, :invalid_integer}
     end
   end
+
+  def call(_input, _opts), do: {:error, :invalid_integer}
 
   defp validate_range(input, min, max) do
     case input do

--- a/lib/surgex/parser/parsers/integer_parser.ex
+++ b/lib/surgex/parser/parsers/integer_parser.ex
@@ -2,8 +2,9 @@ defmodule Surgex.Parser.IntegerParser do
   @moduledoc false
 
   @type errors :: :invalid_integer | :out_of_range
+  @type option :: {:min, integer()} | {:max, integer()}
 
-  @spec call(term(), list) :: {:ok, integer | nil} | {:error, errors}
+  @spec call(term(), [option()]) :: {:ok, integer() | nil} | {:error, errors()}
   def call(input, opts \\ [])
   def call(nil, _opts), do: {:ok, nil}
 

--- a/lib/surgex/parser/parsers/list_parser.ex
+++ b/lib/surgex/parser/parsers/list_parser.ex
@@ -1,7 +1,7 @@
 defmodule Surgex.Parser.ListParser do
   @moduledoc false
 
-  @spec call(Surgex.Types.json_value()) :: {:ok, [any]} | {:error, :invalid_list}
+  @spec call(term()) :: {:ok, [term()]} | {:error, :invalid_list}
   def call(nil), do: {:ok, []}
   def call(list) when is_list(list), do: {:ok, list}
   def call(""), do: {:ok, []}

--- a/lib/surgex/parser/parsers/list_parser.ex
+++ b/lib/surgex/parser/parsers/list_parser.ex
@@ -1,7 +1,7 @@
 defmodule Surgex.Parser.ListParser do
   @moduledoc false
 
-  @spec call(any) :: {:ok, [any]} | {:error, :invalid_list}
+  @spec call(Surgex.Types.json_value()) :: {:ok, [any]} | {:error, :invalid_list}
   def call(nil), do: {:ok, []}
   def call(list) when is_list(list), do: {:ok, list}
   def call(""), do: {:ok, []}

--- a/lib/surgex/parser/parsers/list_parser.ex
+++ b/lib/surgex/parser/parsers/list_parser.ex
@@ -1,10 +1,10 @@
 defmodule Surgex.Parser.ListParser do
   @moduledoc false
 
-  @spec call(nil) :: {:ok, []}
-  @spec call([any]) :: {:ok, [any]}
-  @spec call(String.t()) :: {:ok, [String.t()]}
+  @spec call(any) :: {:ok, [any]} | {:error, :invalid_list}
   def call(nil), do: {:ok, []}
   def call(list) when is_list(list), do: {:ok, list}
+  def call(""), do: {:ok, []}
   def call(string) when is_binary(string), do: {:ok, String.split(string, ",")}
+  def call(_input), do: {:error, :invalid_list}
 end

--- a/lib/surgex/parser/parsers/page_parser.ex
+++ b/lib/surgex/parser/parsers/page_parser.ex
@@ -3,8 +3,7 @@ defmodule Surgex.Parser.PageParser do
 
   alias Surgex.Parser.IntegerParser
 
-  @spec call(Surgex.Types.json_value()) ::
-          {:ok, integer | nil} | {:error, :invalid_page} | {:error, IntegerParser.errors()}
+  @spec call(term()) :: {:ok, integer | nil} | {:error, :invalid_page | IntegerParser.errors()}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do

--- a/lib/surgex/parser/parsers/page_parser.ex
+++ b/lib/surgex/parser/parsers/page_parser.ex
@@ -3,7 +3,7 @@ defmodule Surgex.Parser.PageParser do
 
   alias Surgex.Parser.IntegerParser
 
-  @spec call(any) ::
+  @spec call(Surgex.Types.json_value()) ::
           {:ok, integer | nil} | {:error, :invalid_page} | {:error, IntegerParser.errors()}
   def call(nil), do: {:ok, nil}
 

--- a/lib/surgex/parser/parsers/page_parser.ex
+++ b/lib/surgex/parser/parsers/page_parser.ex
@@ -3,9 +3,8 @@ defmodule Surgex.Parser.PageParser do
 
   alias Surgex.Parser.IntegerParser
 
-  @spec call(nil) :: {:ok, nil}
-  @spec call(String.t()) ::
-          {:ok, integer} | {:error, :invalid_page} | {:error, IntegerParser.errors()}
+  @spec call(any) ::
+          {:ok, integer | nil} | {:error, :invalid_page} | {:error, IntegerParser.errors()}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do
@@ -15,4 +14,6 @@ defmodule Surgex.Parser.PageParser do
       {:error, reason} -> {:error, reason}
     end
   end
+
+  def call(_input), do: {:error, :invalid_page}
 end

--- a/lib/surgex/parser/parsers/required_parser.ex
+++ b/lib/surgex/parser/parsers/required_parser.ex
@@ -1,7 +1,7 @@
 defmodule Surgex.Parser.RequiredParser do
   @moduledoc false
 
-  @spec call(any) :: {:ok, any} | {:error, :required}
+  @spec call(Surgex.Types.json_value()) :: {:ok, any} | {:error, :required}
   def call(nil), do: {:error, :required}
   def call([]), do: {:error, :required}
   def call(input), do: {:ok, input}

--- a/lib/surgex/parser/parsers/required_parser.ex
+++ b/lib/surgex/parser/parsers/required_parser.ex
@@ -1,7 +1,7 @@
 defmodule Surgex.Parser.RequiredParser do
   @moduledoc false
 
-  @spec call(Surgex.Types.json_value()) :: {:ok, any} | {:error, :required}
+  @spec call(term()) :: {:ok, any} | {:error, :required}
   def call(nil), do: {:error, :required}
   def call([]), do: {:error, :required}
   def call(input), do: {:ok, input}

--- a/lib/surgex/parser/parsers/required_parser.ex
+++ b/lib/surgex/parser/parsers/required_parser.ex
@@ -1,7 +1,7 @@
 defmodule Surgex.Parser.RequiredParser do
   @moduledoc false
 
-  @spec call(term()) :: {:ok, any} | {:error, :required}
+  @spec call(term()) :: {:ok, term()} | {:error, :required}
   def call(nil), do: {:error, :required}
   def call([]), do: {:error, :required}
   def call(input), do: {:ok, input}

--- a/lib/surgex/parser/parsers/resource_array_parser.ex
+++ b/lib/surgex/parser/parsers/resource_array_parser.ex
@@ -3,7 +3,7 @@ defmodule Surgex.Parser.ResourceArrayParser do
 
   @type errors :: :too_short | :too_long | :invalid_array
 
-  @spec call(Surgex.Types.json_value(), fun, Keyword.t()) :: {:ok, list | nil} | {:error, errors}
+  @spec call(term(), fun, Keyword.t()) :: {:ok, list | nil} | {:error, errors}
   def call(list, item_parser, opts \\ [])
   def call(nil, _item_parser, _opts), do: {:ok, nil}
 

--- a/lib/surgex/parser/parsers/resource_array_parser.ex
+++ b/lib/surgex/parser/parsers/resource_array_parser.ex
@@ -2,8 +2,9 @@ defmodule Surgex.Parser.ResourceArrayParser do
   @moduledoc false
 
   @type errors :: :too_short | :too_long | :invalid_array
+  @type option :: {:min, integer()} | {:max, integer()}
 
-  @spec call(term(), fun, Keyword.t()) :: {:ok, list | nil} | {:error, errors}
+  @spec call(term(), (term() -> term()), [option()]) :: {:ok, list() | nil} | {:error, errors()}
   def call(list, item_parser, opts \\ [])
   def call(nil, _item_parser, _opts), do: {:ok, nil}
 

--- a/lib/surgex/parser/parsers/resource_array_parser.ex
+++ b/lib/surgex/parser/parsers/resource_array_parser.ex
@@ -3,7 +3,7 @@ defmodule Surgex.Parser.ResourceArrayParser do
 
   @type errors :: :too_short | :too_long | :invalid_array
 
-  @spec call(any, fun, Keyword.t()) :: {:ok, list | nil} | {:error, errors}
+  @spec call(Surgex.Types.json_value(), fun, Keyword.t()) :: {:ok, list | nil} | {:error, errors}
   def call(list, item_parser, opts \\ [])
   def call(nil, _item_parser, _opts), do: {:ok, nil}
 

--- a/lib/surgex/parser/parsers/resource_array_parser.ex
+++ b/lib/surgex/parser/parsers/resource_array_parser.ex
@@ -1,10 +1,9 @@
 defmodule Surgex.Parser.ResourceArrayParser do
   @moduledoc false
 
-  @type errors :: :too_short | :too_long
+  @type errors :: :too_short | :too_long | :invalid_array
 
-  @spec call(nil, any, any) :: {:ok, nil}
-  @spec call(list, fun, Keyword.t()) :: {:ok, list} | {:error, errors}
+  @spec call(any, fun, Keyword.t()) :: {:ok, list | nil} | {:error, errors}
   def call(list, item_parser, opts \\ [])
   def call(nil, _item_parser, _opts), do: {:ok, nil}
 
@@ -18,6 +17,8 @@ defmodule Surgex.Parser.ResourceArrayParser do
       {:error, :too_long} -> {:error, :too_long}
     end
   end
+
+  def call(_input, _, _), do: {:error, :invalid_array}
 
   defp validate_length(list, min, max) do
     cond do

--- a/lib/surgex/parser/parsers/resource_id_parser.ex
+++ b/lib/surgex/parser/parsers/resource_id_parser.ex
@@ -3,11 +3,7 @@ defmodule Surgex.Parser.ResourceIdParser do
 
   alias Surgex.Parser.IdParser
 
-  @spec call(Surgex.Types.json_value()) ::
-          {:ok, nil}
-          | {:ok, integer}
-          | {:error, [{IdParser.errors(), String.t()}]}
-          | {:error, [required: String.t()]}
+  @spec call(term()) :: {:ok, integer | nil} | {:error, Keyword.t()}
   def call(nil), do: {:ok, nil}
 
   def call(%{id: id_string}) when is_binary(id_string) do

--- a/lib/surgex/parser/parsers/resource_id_parser.ex
+++ b/lib/surgex/parser/parsers/resource_id_parser.ex
@@ -3,7 +3,7 @@ defmodule Surgex.Parser.ResourceIdParser do
 
   alias Surgex.Parser.IdParser
 
-  @spec call(any) ::
+  @spec call(Surgex.Types.json_value()) ::
           {:ok, nil}
           | {:ok, integer}
           | {:error, [{IdParser.errors(), String.t()}]}

--- a/lib/surgex/parser/parsers/resource_parser.ex
+++ b/lib/surgex/parser/parsers/resource_parser.ex
@@ -1,8 +1,7 @@
 defmodule Surgex.Parser.ResourceParser do
   @moduledoc false
 
-  @spec call(nil, any) :: {:ok, nil}
-  @spec call(map, fun) :: {:ok, any} | {:error, Keyword.t()}
+  @spec call(nil | map, fun) :: {:ok, term() | nil} | {:error, Keyword.t()}
   def call(nil, _item_parser), do: {:ok, nil}
 
   def call(resource, item_parser) do

--- a/lib/surgex/parser/parsers/resource_parser.ex
+++ b/lib/surgex/parser/parsers/resource_parser.ex
@@ -1,14 +1,16 @@
 defmodule Surgex.Parser.ResourceParser do
   @moduledoc false
 
-  @spec call(nil | map, fun) :: {:ok, term() | nil} | {:error, Keyword.t()}
+  @spec call(term(), fun) :: {:ok, term() | nil} | {:error, Keyword.t() | atom()}
   def call(nil, _item_parser), do: {:ok, nil}
 
-  def call(resource, item_parser) do
+  def call(resource, item_parser) when is_map(resource) do
     resource
     |> item_parser.()
     |> close()
   end
+
+  def call(_, _), do: {:error, :invalid_resource}
 
   defp close({:ok, result}), do: {:ok, result}
   defp close({:error, :invalid_pointers, pointers}), do: {:error, pointers}

--- a/lib/surgex/parser/parsers/slug_or_id_parser.ex
+++ b/lib/surgex/parser/parsers/slug_or_id_parser.ex
@@ -3,7 +3,7 @@ defmodule Surgex.Parser.SlugOrIdParser do
 
   alias Surgex.Parser.IdParser
 
-  @spec call(any) :: {:ok, String.t() | nil} | {:error, :invalid_slug}
+  @spec call(Surgex.Types.json_value()) :: {:ok, String.t() | nil} | {:error, :invalid_slug}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do

--- a/lib/surgex/parser/parsers/slug_or_id_parser.ex
+++ b/lib/surgex/parser/parsers/slug_or_id_parser.ex
@@ -3,8 +3,7 @@ defmodule Surgex.Parser.SlugOrIdParser do
 
   alias Surgex.Parser.IdParser
 
-  @spec call(nil) :: {:ok, nil}
-  @spec call(String.t()) :: {:ok, String.t()} | {:error, :invalid_slug}
+  @spec call(any) :: {:ok, String.t() | nil} | {:error, :invalid_slug}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do
@@ -19,4 +18,6 @@ defmodule Surgex.Parser.SlugOrIdParser do
         {:error, :invalid_slug}
     end
   end
+
+  def call(_input), do: {:error, :invalid_slug}
 end

--- a/lib/surgex/parser/parsers/slug_or_id_parser.ex
+++ b/lib/surgex/parser/parsers/slug_or_id_parser.ex
@@ -3,7 +3,7 @@ defmodule Surgex.Parser.SlugOrIdParser do
 
   alias Surgex.Parser.IdParser
 
-  @spec call(Surgex.Types.json_value()) :: {:ok, String.t() | nil} | {:error, :invalid_slug}
+  @spec call(term()) :: {:ok, String.t() | nil} | {:error, :invalid_slug}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do

--- a/lib/surgex/parser/parsers/slug_parser.ex
+++ b/lib/surgex/parser/parsers/slug_parser.ex
@@ -1,7 +1,7 @@
 defmodule Surgex.Parser.SlugParser do
   @moduledoc false
 
-  @spec call(Surgex.Types.json_value()) :: {:ok, String.t() | nil} | {:error, :invalid_slug}
+  @spec call(term()) :: {:ok, String.t() | nil} | {:error, :invalid_slug}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do

--- a/lib/surgex/parser/parsers/slug_parser.ex
+++ b/lib/surgex/parser/parsers/slug_parser.ex
@@ -1,7 +1,7 @@
 defmodule Surgex.Parser.SlugParser do
   @moduledoc false
 
-  @spec call(any) :: {:ok, String.t() | nil} | {:error, :invalid_slug}
+  @spec call(Surgex.Types.json_value()) :: {:ok, String.t() | nil} | {:error, :invalid_slug}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do

--- a/lib/surgex/parser/parsers/slug_parser.ex
+++ b/lib/surgex/parser/parsers/slug_parser.ex
@@ -1,8 +1,7 @@
 defmodule Surgex.Parser.SlugParser do
   @moduledoc false
 
-  @spec call(nil) :: {:ok, nil}
-  @spec call(String.t()) :: {:ok, String.t()} | {:error, :invalid_slug}
+  @spec call(any) :: {:ok, String.t() | nil} | {:error, :invalid_slug}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do
@@ -12,4 +11,6 @@ defmodule Surgex.Parser.SlugParser do
       {:error, :invalid_slug}
     end
   end
+
+  def call(_input), do: {:error, :invalid_slug}
 end

--- a/lib/surgex/parser/parsers/sort_parser.ex
+++ b/lib/surgex/parser/parsers/sort_parser.ex
@@ -8,7 +8,7 @@ defmodule Surgex.Parser.SortParser do
   """
 
   @doc false
-  @spec call(any, [atom]) :: {:ok, nil | {:asc | :desc, atom}} | {:error, :invalid_sort_column}
+  @spec call(Surgex.Types.json_value(), [atom]) :: {:ok, nil | {:asc | :desc, atom}} | {:error, :invalid_sort_column}
   def call(nil, _allowed_columns), do: {:ok, nil}
 
   def call(input, allowed_columns) when is_binary(input) do

--- a/lib/surgex/parser/parsers/sort_parser.ex
+++ b/lib/surgex/parser/parsers/sort_parser.ex
@@ -8,7 +8,8 @@ defmodule Surgex.Parser.SortParser do
   """
 
   @doc false
-  @spec call(Surgex.Types.json_value(), [atom]) :: {:ok, nil | {:asc | :desc, atom}} | {:error, :invalid_sort_column}
+  @spec call(Surgex.Types.json_value(), [atom]) ::
+          {:ok, nil | {:asc | :desc, atom}} | {:error, :invalid_sort_column}
   def call(nil, _allowed_columns), do: {:ok, nil}
 
   def call(input, allowed_columns) when is_binary(input) do

--- a/lib/surgex/parser/parsers/sort_parser.ex
+++ b/lib/surgex/parser/parsers/sort_parser.ex
@@ -8,8 +8,7 @@ defmodule Surgex.Parser.SortParser do
   """
 
   @doc false
-  @spec call(nil, any) :: {:ok, nil}
-  @spec call(String.t(), [atom]) :: {:ok, {:asc | :desc, atom}} | {:error, :invalid_sort_column}
+  @spec call(any, [atom]) :: {:ok, nil | {:asc | :desc, atom}} | {:error, :invalid_sort_column}
   def call(nil, _allowed_columns), do: {:ok, nil}
 
   def call(input, allowed_columns) when is_binary(input) do
@@ -21,6 +20,8 @@ defmodule Surgex.Parser.SortParser do
         validate_allowed_columns(column, allowed_columns, :asc)
     end
   end
+
+  def call(_input, _), do: {:error, :invalid_sort_column}
 
   defp validate_allowed_columns(column, allowed_columns, direction) do
     column_atom = atomize_maybe_dasherized(column)

--- a/lib/surgex/parser/parsers/sort_parser.ex
+++ b/lib/surgex/parser/parsers/sort_parser.ex
@@ -8,8 +8,7 @@ defmodule Surgex.Parser.SortParser do
   """
 
   @doc false
-  @spec call(Surgex.Types.json_value(), [atom]) ::
-          {:ok, nil | {:asc | :desc, atom}} | {:error, :invalid_sort_column}
+  @spec call(term(), [atom]) :: {:ok, {:asc | :desc, atom} | nil} | {:error, :invalid_sort_column}
   def call(nil, _allowed_columns), do: {:ok, nil}
 
   def call(input, allowed_columns) when is_binary(input) do

--- a/lib/surgex/parser/parsers/string_parser.ex
+++ b/lib/surgex/parser/parsers/string_parser.ex
@@ -8,7 +8,7 @@ defmodule Surgex.Parser.StringParser do
   @type errors :: :too_short | :too_long | :invalid_string
   @opts [:trim, :min, :max]
 
-  @spec call(Surgex.Types.json_value(), list) :: {:ok, String.t() | nil} | {:error, errors}
+  @spec call(term(), list) :: {:ok, String.t() | nil} | {:error, errors}
   def call(input, opts \\ [])
   def call(nil, _opts), do: {:ok, nil}
 

--- a/lib/surgex/parser/parsers/string_parser.ex
+++ b/lib/surgex/parser/parsers/string_parser.ex
@@ -5,11 +5,10 @@ defmodule Surgex.Parser.StringParser do
   - **min** is a minimal length of the string, returns :too_short error symbol
   - **max** is a maximal length of the string, returns :too_long error symbol
   """
-  @type errors :: :too_short | :too_long
+  @type errors :: :too_short | :too_long | :invalid_string
   @opts [:trim, :min, :max]
 
-  @spec call(nil, any) :: {:ok, nil}
-  @spec call(String.t(), list) :: {:ok, String.t()} | {:error, errors}
+  @spec call(any, list) :: {:ok, String.t() | nil} | {:error, errors}
   def call(input, opts \\ [])
   def call(nil, _opts), do: {:ok, nil}
 
@@ -26,6 +25,8 @@ defmodule Surgex.Parser.StringParser do
       %{error: error} -> {:error, error}
     end
   end
+
+  def call(_input, _opts), do: {:error, :invalid_string}
 
   @spec validate_opts!(list) :: :ok
   defp validate_opts!([]), do: :ok

--- a/lib/surgex/parser/parsers/string_parser.ex
+++ b/lib/surgex/parser/parsers/string_parser.ex
@@ -8,7 +8,7 @@ defmodule Surgex.Parser.StringParser do
   @type errors :: :too_short | :too_long | :invalid_string
   @opts [:trim, :min, :max]
 
-  @spec call(any, list) :: {:ok, String.t() | nil} | {:error, errors}
+  @spec call(Surgex.Types.json_value(), list) :: {:ok, String.t() | nil} | {:error, errors}
   def call(input, opts \\ [])
   def call(nil, _opts), do: {:ok, nil}
 

--- a/lib/surgex/parser/parsers/string_parser.ex
+++ b/lib/surgex/parser/parsers/string_parser.ex
@@ -6,9 +6,10 @@ defmodule Surgex.Parser.StringParser do
   - **max** is a maximal length of the string, returns :too_long error symbol
   """
   @type errors :: :too_short | :too_long | :invalid_string
+  @type option :: {:trim, boolean()} | {:min, integer()} | {:max, integer()}
   @opts [:trim, :min, :max]
 
-  @spec call(term(), list) :: {:ok, String.t() | nil} | {:error, errors}
+  @spec call(term(), [option()]) :: {:ok, String.t() | nil} | {:error, errors()}
   def call(input, opts \\ [])
   def call(nil, _opts), do: {:ok, nil}
 

--- a/lib/surgex/parser/parsers/time_parser.ex
+++ b/lib/surgex/parser/parsers/time_parser.ex
@@ -7,8 +7,7 @@ defmodule Surgex.Parser.TimeParser do
 
   @day_secs 60 * 60 * 24
 
-  @spec call(nil) :: {:ok, nil}
-  @spec call(String.t()) :: {:ok, integer} | {:error, errors}
+  @spec call(any) :: {:ok, integer | nil} | {:error, errors}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do
@@ -19,4 +18,5 @@ defmodule Surgex.Parser.TimeParser do
 
   def call(secs) when is_integer(secs) and secs >= 0 and secs <= @day_secs, do: {:ok, secs}
   def call(secs) when is_integer(secs), do: {:error, :invalid_time}
+  def call(_input), do: {:error, :invalid_time}
 end

--- a/lib/surgex/parser/parsers/time_parser.ex
+++ b/lib/surgex/parser/parsers/time_parser.ex
@@ -7,7 +7,7 @@ defmodule Surgex.Parser.TimeParser do
 
   @day_secs 60 * 60 * 24
 
-  @spec call(any) :: {:ok, integer | nil} | {:error, errors}
+  @spec call(Surgex.Types.json_value()) :: {:ok, integer | nil} | {:error, errors}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do

--- a/lib/surgex/parser/parsers/time_parser.ex
+++ b/lib/surgex/parser/parsers/time_parser.ex
@@ -7,7 +7,7 @@ defmodule Surgex.Parser.TimeParser do
 
   @day_secs 60 * 60 * 24
 
-  @spec call(Surgex.Types.json_value()) :: {:ok, integer | nil} | {:error, errors}
+  @spec call(term()) :: {:ok, integer | nil} | {:error, errors}
   def call(nil), do: {:ok, nil}
 
   def call(input) when is_binary(input) do

--- a/lib/surgex/types.ex
+++ b/lib/surgex/types.ex
@@ -1,0 +1,5 @@
+defmodule Surgex.Types do
+  @moduledoc false
+
+  @type json_value :: number | String.t() | nil | list | map
+end

--- a/lib/surgex/types.ex
+++ b/lib/surgex/types.ex
@@ -1,5 +1,0 @@
-defmodule Surgex.Types do
-  @moduledoc false
-
-  @type json_value :: number | String.t() | nil | list | map
-end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Surgex.Mixfile do
   def project do
     [
       app: :surgex,
-      version: "4.2.0",
+      version: "4.3.0",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Surgex.Mixfile do
   def project do
     [
       app: :surgex,
-      version: "4.3.0",
+      version: "4.2.1",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,

--- a/test/surgex/parser/parsers/boolean_parser_test.exs
+++ b/test/surgex/parser/parsers/boolean_parser_test.exs
@@ -15,5 +15,7 @@ defmodule Surgex.Parser.BooleanParserTest do
 
   test "invalid input" do
     assert BooleanParser.call("?") == {:error, :invalid_boolean}
+    assert BooleanParser.call(2) == {:error, :invalid_boolean}
+    assert BooleanParser.call(0.5) == {:error, :invalid_boolean}
   end
 end

--- a/test/surgex/parser/parsers/date_parser_test.exs
+++ b/test/surgex/parser/parsers/date_parser_test.exs
@@ -14,5 +14,7 @@ defmodule Surgex.Parser.DateParserTest do
     assert DateParser.call("2015-1-1") == {:error, :invalid_date}
     assert DateParser.call("2015-02-30") == {:error, :invalid_date}
     assert DateParser.call("abc") == {:error, :invalid_date}
+    assert DateParser.call(17) == {:error, :invalid_date}
+    assert DateParser.call(["2015-02-01"]) == {:error, :invalid_date}
   end
 end

--- a/test/surgex/parser/parsers/email_parser_test.exs
+++ b/test/surgex/parser/parsers/email_parser_test.exs
@@ -29,4 +29,10 @@ defmodule Surgex.Parser.EmailParserTest do
     assert EmailParser.call("he llo@example.com") == {:error, :invalid_email}
     assert EmailParser.call("me@example@gmail.com") == {:error, :invalid_email}
   end
+
+  test "unsupported input" do
+    assert EmailParser.call(15) == {:error, :invalid_email}
+    assert EmailParser.call(0.5) == {:error, :invalid_email}
+    assert EmailParser.call(["me@example@gmail.com"]) == {:error, :invalid_email}
+  end
 end

--- a/test/surgex/parser/parsers/float_parser_test.exs
+++ b/test/surgex/parser/parsers/float_parser_test.exs
@@ -23,4 +23,8 @@ defmodule Surgex.Parser.FloatParserTest do
     assert FloatParser.call("1.5", min: 1.6) == {:error, :out_of_range}
     assert FloatParser.call("1.5", max: 1.4) == {:error, :out_of_range}
   end
+
+  test "unsupported input type" do
+    assert FloatParser.call(["1.3"]) == {:error, :invalid_float}
+  end
 end

--- a/test/surgex/parser/parsers/geobox_parser_test.exs
+++ b/test/surgex/parser/parsers/geobox_parser_test.exs
@@ -40,4 +40,11 @@ defmodule Surgex.Parser.GeoboxParserTest do
     assert GeoboxParser.call("-22.302,-17.891,-22.203") == {:error, :invalid_geobox_tuple}
     assert GeoboxParser.call("?") == {:error, :invalid_geobox_tuple}
   end
+
+  test "unsupported input type" do
+    assert GeoboxParser.call(1) == {:error, :invalid_geobox_tuple}
+    assert GeoboxParser.call(1.5) == {:error, :invalid_geobox_tuple}
+    assert GeoboxParser.call(["30.1,-179.85,29.9,179.95"]) == {:error, :invalid_geobox_tuple}
+    assert GeoboxParser.call(%{box: true}) == {:error, :invalid_geobox_tuple}
+  end
 end

--- a/test/surgex/parser/parsers/geolocation_parser_test.exs
+++ b/test/surgex/parser/parsers/geolocation_parser_test.exs
@@ -16,4 +16,10 @@ defmodule Surgex.Parser.GeolocationParserTest do
     assert GeolocationParser.call("?") == {:error, :invalid_geolocation_tuple}
     assert GeolocationParser.call("-22.203,?") == {:error, :invalid_float}
   end
+
+  test "unsupported input type" do
+    assert GeolocationParser.call(1) == {:error, :invalid_geolocation_tuple}
+    assert GeolocationParser.call(6.7) == {:error, :invalid_geolocation_tuple}
+    assert GeolocationParser.call(["12.345,67.891"]) == {:error, :invalid_geolocation_tuple}
+  end
 end

--- a/test/surgex/parser/parsers/id_list_parser_test.exs
+++ b/test/surgex/parser/parsers/id_list_parser_test.exs
@@ -26,4 +26,9 @@ defmodule Surgex.Parser.IdListParserTest do
     assert IdListParser.call([1, -2, 3]) == {:error, :invalid_identifier}
     assert IdListParser.call(["1", "-2", "3"]) == {:error, :invalid_identifier}
   end
+
+  test "unsupported input type" do
+    assert IdListParser.call(1.5) == {:error, :invalid_id_list}
+    assert IdListParser.call(%{id: 1.5}) == {:error, :invalid_id_list}
+  end
 end

--- a/test/surgex/parser/parsers/id_parser_test.exs
+++ b/test/surgex/parser/parsers/id_parser_test.exs
@@ -15,4 +15,9 @@ defmodule Surgex.Parser.IdParserTest do
     assert IdParser.call("123abc") == {:error, :invalid_integer}
     assert IdParser.call("?") == {:error, :invalid_integer}
   end
+
+  test "unsupported input type" do
+    assert IdParser.call(1.5) == {:error, :invalid_identifier}
+    assert IdParser.call(["1"]) == {:error, :invalid_identifier}
+  end
 end

--- a/test/surgex/parser/parsers/include_parser_test.exs
+++ b/test/surgex/parser/parsers/include_parser_test.exs
@@ -26,6 +26,10 @@ defmodule Surgex.Parser.IncludeParserTest do
       assert IncludeParser.call("other,user.ledger-account", [:user, :"user.ledger-account"]) ==
                {:error, :invalid_relationship_path}
     end
+
+    test "unsupported input type" do
+      assert IncludeParser.call(0.3, [:user]) == {:error, :invalid_input}
+    end
   end
 
   describe "flatten/2" do

--- a/test/surgex/parser/parsers/integer_parser_test.exs
+++ b/test/surgex/parser/parsers/integer_parser_test.exs
@@ -19,4 +19,10 @@ defmodule Surgex.Parser.IntegerParserTest do
     assert IntegerParser.call("1", min: 2) == {:error, :out_of_range}
     assert IntegerParser.call("1", max: 0) == {:error, :out_of_range}
   end
+
+  test "unsupported input type" do
+    assert IntegerParser.call(0.5) == {:error, :invalid_integer}
+    assert IntegerParser.call([1]) == {:error, :invalid_integer}
+    assert IntegerParser.call(%{test: 1}) == {:error, :invalid_integer}
+  end
 end

--- a/test/surgex/parser/parsers/list_parser_test.exs
+++ b/test/surgex/parser/parsers/list_parser_test.exs
@@ -6,6 +6,10 @@ defmodule Surgex.Parser.ListParserTest do
     assert ListParser.call(nil) == {:ok, []}
   end
 
+  test "empty string" do
+    assert ListParser.call("") == {:ok, []}
+  end
+
   test "valid input" do
     assert ListParser.call(["a", 1]) == {:ok, ["a", 1]}
     assert ListParser.call("a,1") == {:ok, ["a", "1"]}

--- a/test/surgex/parser/parsers/page_parser_test.exs
+++ b/test/surgex/parser/parsers/page_parser_test.exs
@@ -16,4 +16,9 @@ defmodule Surgex.Parser.PageParserTest do
     assert PageParser.call("123abc") == {:error, :invalid_integer}
     assert PageParser.call("?") == {:error, :invalid_integer}
   end
+
+  test "unsupported input type" do
+    assert PageParser.call(1.5) == {:error, :invalid_page}
+    assert PageParser.call([1]) == {:error, :invalid_page}
+  end
 end

--- a/test/surgex/parser/parsers/required_parser_test.exs
+++ b/test/surgex/parser/parsers/required_parser_test.exs
@@ -5,6 +5,8 @@ defmodule Surgex.Parser.RequiredParserTest do
   test "valid input" do
     assert RequiredParser.call(123) == {:ok, 123}
     assert RequiredParser.call("abc") == {:ok, "abc"}
+    assert RequiredParser.call(1.23) == {:ok, 1.23}
+    assert RequiredParser.call(%{}) == {:ok, %{}}
   end
 
   test "invalid input" do

--- a/test/surgex/parser/parsers/resource_parser_test.exs
+++ b/test/surgex/parser/parsers/resource_parser_test.exs
@@ -23,6 +23,6 @@ defmodule Surgex.Parser.ResourceParserTest do
   end
 
   test "non-map input" do
-    assert ResourceParser.call(5, & to_string(&1)) == {:error, :invalid_resource}
+    assert ResourceParser.call(5, &to_string(&1)) == {:error, :invalid_resource}
   end
 end

--- a/test/surgex/parser/parsers/resource_parser_test.exs
+++ b/test/surgex/parser/parsers/resource_parser_test.exs
@@ -21,4 +21,8 @@ defmodule Surgex.Parser.ResourceParserTest do
              {:error, :invalid_pointers, [id: "id"]}
            end) == {:error, [id: "id"]}
   end
+
+  test "non-map input" do
+    assert ResourceParser.call(5, & to_string(&1)) == {:error, :invalid_resource}
+  end
 end

--- a/test/surgex/parser/parsers/slug_or_id_parser_test.exs
+++ b/test/surgex/parser/parsers/slug_or_id_parser_test.exs
@@ -17,4 +17,9 @@ defmodule Surgex.Parser.SlugOrIdParserTest do
     assert SlugOrIdParser.call("abć-123") == {:error, :invalid_slug}
     assert SlugOrIdParser.call("abć%20123") == {:error, :invalid_slug}
   end
+
+  test "unsupported input type" do
+    assert SlugOrIdParser.call(0.3) == {:error, :invalid_slug}
+    assert SlugOrIdParser.call(["123"]) == {:error, :invalid_slug}
+  end
 end

--- a/test/surgex/parser/parsers/slug_parser_test.exs
+++ b/test/surgex/parser/parsers/slug_parser_test.exs
@@ -15,4 +15,9 @@ defmodule Surgex.Parser.SlugParserTest do
     assert SlugParser.call("abć-123") == {:error, :invalid_slug}
     assert SlugParser.call("abć%20123") == {:error, :invalid_slug}
   end
+
+  test "unsupported input type" do
+    assert SlugParser.call(1.33) == {:error, :invalid_slug}
+    assert SlugParser.call(["abc-123"]) == {:error, :invalid_slug}
+  end
 end

--- a/test/surgex/parser/parsers/sort_parser_test.exs
+++ b/test/surgex/parser/parsers/sort_parser_test.exs
@@ -16,6 +16,10 @@ defmodule Surgex.Parser.SortParserTest do
     test "invalid input" do
       assert SortParser.call("other", [:id, :name]) == {:error, :invalid_sort_column}
     end
+
+    test "unsupported input type" do
+      assert SortParser.call(1, [String.to_atom("1")]) == {:error, :invalid_sort_column}
+    end
   end
 
   describe "flatten/2" do

--- a/test/surgex/parser/parsers/string_parser_test.exs
+++ b/test/surgex/parser/parsers/string_parser_test.exs
@@ -45,4 +45,8 @@ defmodule Surgex.Parser.StringParserTest do
     assert StringParser.call("  abc  ", opt) == {:ok, "abc"}
     assert StringParser.call("  abcde  ", opt) == {:error, :too_long}
   end
+
+  test "unsupported input type" do
+    assert StringParser.call(1.4) == {:error, :invalid_string}
+  end
 end

--- a/test/surgex/parser/parsers/time_parser_test.exs
+++ b/test/surgex/parser/parsers/time_parser_test.exs
@@ -16,4 +16,9 @@ defmodule Surgex.Parser.TimeParserTest do
     assert TimeParser.call("abc") == {:error, :invalid_integer}
     assert TimeParser.call(Integer.to_string(24 * 60 * 60 + 1)) == {:error, :invalid_time}
   end
+
+  test "unsupported input type" do
+    assert TimeParser.call(0.1) == {:error, :invalid_time}
+    assert TimeParser.call(["0"]) == {:error, :invalid_time}
+  end
 end


### PR DESCRIPTION
Right now parsers can fail with `FunctionClauseError` when a value with not matching type is passed to them, for example when you pass a float to integer parser. However it would seem that they should handle at least all possible JSON values and return error tuple, not an exception.