### PR TITLE
Extend parsing of boolean and integer values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.2.1
+
+- Extended parsing of boolean ("true" -> true, "false" -> false) and integers ("" -> nil) values
+
 ## 4.2.0
 
 - Added support for translating errors in nested changeset to JSON API responses

--- a/lib/surgex/parser/parsers/boolean_parser.ex
+++ b/lib/surgex/parser/parsers/boolean_parser.ex
@@ -8,6 +8,8 @@ defmodule Surgex.Parser.BooleanParser do
   def call(nil), do: {:ok, nil}
   def call("0"), do: {:ok, false}
   def call("1"), do: {:ok, true}
+  def call("false"), do: {:ok, false}
+  def call("true"), do: {:ok, true}
   def call(false), do: {:ok, false}
   def call(true), do: {:ok, true}
   def call(_input), do: {:error, :invalid_boolean}

--- a/lib/surgex/parser/parsers/integer_parser.ex
+++ b/lib/surgex/parser/parsers/integer_parser.ex
@@ -7,6 +7,7 @@ defmodule Surgex.Parser.IntegerParser do
   @spec call(String.t() | integer, list) :: {:ok, integer} | {:error, errors}
   def call(input, opts \\ [])
   def call(nil, _opts), do: {:ok, nil}
+  def call("", _opts), do: {:ok, nil}
 
   def call(input, opts) when is_integer(input) do
     min = Keyword.get(opts, :min)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Surgex.Mixfile do
   def project do
     [
       app: :surgex,
-      version: "4.2.0",
+      version: "4.2.1",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,

--- a/test/surgex/parser/parsers/boolean_parser_test.exs
+++ b/test/surgex/parser/parsers/boolean_parser_test.exs
@@ -9,6 +9,8 @@ defmodule Surgex.Parser.BooleanParserTest do
   test "valid input" do
     assert BooleanParser.call("0") == {:ok, false}
     assert BooleanParser.call("1") == {:ok, true}
+    assert BooleanParser.call("false") == {:ok, false}
+    assert BooleanParser.call("true") == {:ok, true}
     assert BooleanParser.call(false) == {:ok, false}
     assert BooleanParser.call(true) == {:ok, true}
   end

--- a/test/surgex/parser/parsers/integer_parser_test.exs
+++ b/test/surgex/parser/parsers/integer_parser_test.exs
@@ -6,6 +6,10 @@ defmodule Surgex.Parser.IntegerParserTest do
     assert IntegerParser.call(nil) == {:ok, nil}
   end
 
+  test "empty string" do
+    assert IntegerParser.call("") == {:ok, nil}
+  end
+
   test "valid input" do
     assert IntegerParser.call(123) == {:ok, 123}
     assert IntegerParser.call("123") == {:ok, 123}


### PR DESCRIPTION
# Description

Extend parsing of boolean and integer values because of change in `Plug.Test` https://github.com/phoenixframework/phoenix/issues/3605

Additional matches:
- boolean `"true" -> true` and `"false" -> false`
- integers `"" -> nil`

After the new version of Surgex is added to all our apps we can update the Plug to `v1.12`.