### PR TITLE
Bump minor version to v4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.3.0
+
+- Bump minor version
+
 ## 4.2.1
 
 - Extended parsing of boolean ("true" -> true, "false" -> false) and integers ("" -> nil) values

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Surgex.Mixfile do
   def project do
     [
       app: :surgex,
-      version: "4.2.1",
+      version: "4.3.0",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
## Description

The previous version should be minor not patch.

[SemVer](https://semver.org/)
> Bug fixes not affecting the API increment the patch version, backwards compatible API additions/changes increment the minor version, and backwards incompatible API changes increment the major version.