### PR TITLE
Extend parsing of ResourceID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.4.0
+
+- Extended parsing of ResourceID ("" -> required)
+
 ## 4.3.0
 
 - Bump minor version

--- a/lib/surgex/parser/parsers/resource_id_parser.ex
+++ b/lib/surgex/parser/parsers/resource_id_parser.ex
@@ -10,6 +10,8 @@ defmodule Surgex.Parser.ResourceIdParser do
           | {:error, [required: String.t()]}
   def call(nil), do: {:ok, nil}
 
+  def call(%{id: ""}), do: {:error, [required: "id"]}
+
   def call(%{id: id_string}) when is_binary(id_string) do
     with {:error, reason} <- IdParser.call(id_string) do
       {:error, [{reason, "id"}]}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Surgex.Mixfile do
   def project do
     [
       app: :surgex,
-      version: "4.3.0",
+      version: "4.4.0",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,

--- a/test/surgex/parser/parsers/id_parser_test.exs
+++ b/test/surgex/parser/parsers/id_parser_test.exs
@@ -6,6 +6,10 @@ defmodule Surgex.Parser.IdParserTest do
     assert IdParser.call(nil) == {:ok, nil}
   end
 
+  test "empty string" do
+    assert IdParser.call("") == {:ok, nil}
+  end
+
   test "valid input" do
     assert IdParser.call("123") == {:ok, 123}
   end

--- a/test/surgex/parser/parsers/resource_id_parser_test.exs
+++ b/test/surgex/parser/parsers/resource_id_parser_test.exs
@@ -13,6 +13,7 @@ defmodule Surgex.Parser.ResourceIdParserTest do
   test "invalid input" do
     assert ResourceIdParser.call(%{id: "0"}) == {:error, [invalid_identifier: "id"]}
     assert ResourceIdParser.call(%{id: nil}) == {:error, [required: "id"]}
+    assert ResourceIdParser.call(%{id: ""}) == {:error, [required: "id"]}
     assert ResourceIdParser.call(%{}) == {:error, [required: "id"]}
   end
 end


### PR DESCRIPTION
## Description

Extend parsing of ResourceID, empty string should be parsed the same as `nil` value.