### PR TITLE
Update Surgex.Parser.ResourceArrayParser to support invalid parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.6.0
+
+- Updated `Surgex.Parser.ResourceArrayParser` to support invalid parameters
+
 ## 4.5.0
 
 - Extended parsers to match empty string values as nil

--- a/lib/surgex/parser/parsers/resource_array_parser.ex
+++ b/lib/surgex/parser/parsers/resource_array_parser.ex
@@ -45,7 +45,8 @@ defmodule Surgex.Parser.ResourceArrayParser do
     {[result | output], errors}
   end
 
-  defp reduce({{:error, :invalid_pointers, pointers}, index}, {output, errors}) do
+  defp reduce({{:error, error_type, pointers}, index}, {output, errors})
+       when error_type in [:invalid_parameters, :invalid_pointers] do
     new_errors =
       Enum.map(pointers, fn {reason, pointer} ->
         {reason, "#{index}/#{pointer}"}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Surgex.Mixfile do
   def project do
     [
       app: :surgex,
-      version: "4.5.0",
+      version: "4.6.0",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,

--- a/test/surgex/parser/parsers/resource_array_parser_test.exs
+++ b/test/surgex/parser/parsers/resource_array_parser_test.exs
@@ -23,12 +23,20 @@ defmodule Surgex.Parser.ResourceArrayParserTest do
            ) == {:ok, [[id: "123"], [id: "456"]]}
   end
 
-  test "invalid input" do
+  test "invalid pointer input" do
     assert ResourceArrayParser.call([%{id: "123"}, %{id: "456"}], fn resource ->
              assert %{id: _} = resource
 
              {:error, :invalid_pointers, [id: "id"]}
            end) == {:error, [id: "0/id", id: "1/id"]}
+  end
+
+  test "invalid parameter input" do
+    assert ResourceArrayParser.call([%{value: "123"}, %{value: "456"}], fn resource ->
+             assert %{value: _} = resource
+
+             {:error, :invalid_parameters, [required: "value"]}
+           end) == {:error, [required: "0/value", required: "1/value"]}
   end
 
   test "min out of range" do


### PR DESCRIPTION
## Description

Update `Surgex.Parser.ResourceArrayParser` to support invalid parameters, it used to support only invalid pointers.