### PR TITLE
option to resolve ambiguous hour in datetime helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 4.8.1
+
+- Added an option to resolve ambiguous datetime in `Surgex.DateTime.date_and_offset_to_datetime/3` helper
+
 ## 4.8.0
 
 - New `Surgex.DateTime` module with `date_and_offset_to_datetime/3` helper for creating UTC or time-zone date time

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Surgex.Mixfile do
   def project do
     [
       app: :surgex,
-      version: "4.8.0",
+      version: "4.8.1",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,

--- a/test/surgex/date_time/date_time_test.exs
+++ b/test/surgex/date_time/date_time_test.exs
@@ -43,7 +43,7 @@ defmodule Surgex.DateTimeTest do
     end
   end
 
-  describe "date_and_offset_to_datetime/3 on DST dates" do
+  describe "date_and_offset_to_datetime/4 on DST dates" do
     setup do
       %{
         dst_dates: [
@@ -133,9 +133,30 @@ defmodule Surgex.DateTimeTest do
                 minute: 0,
                 month: 10,
                 second: 0,
+                std_offset: 0,
                 time_zone: ^time_zone,
                 year: 2021
               }} = Surgex.DateTime.date_and_offset_to_datetime(date, 1 * @hour, time_zone)
+
+      ambiguous_hour_pref = :before
+
+      assert {:ok,
+              %DateTime{
+                day: 31,
+                hour: 1,
+                minute: 0,
+                month: 10,
+                second: 0,
+                std_offset: 3600,
+                time_zone: ^time_zone,
+                year: 2021
+              }} =
+               Surgex.DateTime.date_and_offset_to_datetime(
+                 date,
+                 1 * @hour,
+                 time_zone,
+                 ambiguous_hour_pref
+               )
     end
 
     test "ambiguous autumn hour in Australia time zone", %{dst_dates: dates} do
@@ -145,13 +166,34 @@ defmodule Surgex.DateTimeTest do
       assert {:ok,
               %DateTime{
                 day: 3,
-                hour: 1,
+                hour: 2,
                 minute: 0,
                 month: 4,
                 second: 0,
+                std_offset: 0,
                 time_zone: ^time_zone,
                 year: 2022
-              }} = Surgex.DateTime.date_and_offset_to_datetime(date, 1 * @hour, time_zone)
+              }} = Surgex.DateTime.date_and_offset_to_datetime(date, 2 * @hour, time_zone)
+
+      ambiguous_hour_pref = :before
+
+      assert {:ok,
+              %DateTime{
+                day: 3,
+                hour: 2,
+                minute: 0,
+                month: 4,
+                second: 0,
+                std_offset: 3600,
+                time_zone: ^time_zone,
+                year: 2022
+              }} =
+               Surgex.DateTime.date_and_offset_to_datetime(
+                 date,
+                 2 * @hour,
+                 time_zone,
+                 ambiguous_hour_pref
+               )
     end
 
     test "error on non-existent ambiguous spring hour", %{dst_dates: dates} do


### PR DESCRIPTION
This PR provides an option in the `date_and_offset_to_datetime` helper to resolve ambiguous datetimes (when 2 timezones are applicable) during DST, instead of only returning datetime from the later `after` timezone as there may be cases in which datetime from the earlier `before` timezone is needed.