### PR TITLE
Regex options in StringParser + UUID parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 ## 4.9.0
 
-- New `:regex` option for string parser, allowing checking input agains given pattern
-- New UUID parser
+- New `:regex` option for `Surgex.Parser.StringParser`, allowing checking input agains given pattern
+- New UUID parser (`Surgex.Parser.UuidParser`)
+- Add support for :min, :max and :trim option for `Surgex.Parser.EmailParser`
 
 ## 4.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## Unreleased
+## 4.9.0
 
 - New `:regex` option for string parser, allowing checking input agains given pattern
 - New UUID parser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## Unreleased
+
+- New `:regex` option for string parser, allowing checking input agains given pattern
+- New UUID parser
+
 ## 4.8.0
 
 - New `Surgex.DateTime` module with `date_and_offset_to_datetime/3` helper for creating UTC or time-zone date time

--- a/lib/surgex/parser/parsers/email_parser.ex
+++ b/lib/surgex/parser/parsers/email_parser.ex
@@ -5,16 +5,21 @@ defmodule Surgex.Parser.EmailParser do
 
   @email_regex ~r/^[^@\s]+@[^@\s]+\.[^@\s]+$/i
 
-  @spec call(term()) :: {:ok, String.t() | nil} | {:error, :invalid_email}
-  def call(nil), do: {:ok, nil}
-  def call(""), do: {:ok, nil}
+  @type errors :: :invalid_email | StringParser.errors()
 
-  def call(input) when is_binary(input) do
-    case StringParser.call(input, regex: @email_regex) do
+  @spec call(term(), Keyword.t()) :: {:ok, String.t() | nil} | {:error, errors()}
+  @spec call(any) :: {:ok, String.t() | nil} | {:error, errors()}
+  def call(input), do: call(input, [])
+  def call(nil, _), do: {:ok, nil}
+  def call("", _), do: {:ok, nil}
+
+  def call(input, opts) when is_binary(input) do
+    case StringParser.call(input, Keyword.put(opts, :regex, @email_regex)) do
       {:ok, input} -> {:ok, input}
       {:error, :bad_format} -> {:error, :invalid_email}
+      error -> error
     end
   end
 
-  def call(_input), do: {:error, :invalid_email}
+  def call(_input, _), do: {:error, :invalid_email}
 end

--- a/lib/surgex/parser/parsers/email_parser.ex
+++ b/lib/surgex/parser/parsers/email_parser.ex
@@ -1,6 +1,8 @@
 defmodule Surgex.Parser.EmailParser do
   @moduledoc false
 
+  alias Surgex.Parser.StringParser
+
   @email_regex ~r/^[^@\s]+@[^@\s]+\.[^@\s]+$/i
 
   @spec call(term()) :: {:ok, String.t() | nil} | {:error, :invalid_email}
@@ -8,10 +10,9 @@ defmodule Surgex.Parser.EmailParser do
   def call(""), do: {:ok, nil}
 
   def call(input) when is_binary(input) do
-    if Regex.match?(@email_regex, input) do
-      {:ok, input}
-    else
-      {:error, :invalid_email}
+    case StringParser.call(input, regex: @email_regex) do
+      {:ok, input} -> {:ok, input}
+      {:error, :bad_format} -> {:error, :invalid_email}
     end
   end
 

--- a/lib/surgex/parser/parsers/string_parser.ex
+++ b/lib/surgex/parser/parsers/string_parser.ex
@@ -97,10 +97,10 @@ defmodule Surgex.Parser.StringParser do
   end
 
   @spec check_regex(%{opts: list, value: String.t(), error: nil}) :: %{
-    opts: list,
-    value: String.t(),
-    error: nil | :bad_format
-  }
+          opts: list,
+          value: String.t(),
+          error: nil | :bad_format
+        }
   def check_regex(input = %{opts: opts, value: value}) do
     regex = Keyword.get(opts, :regex)
 

--- a/lib/surgex/parser/parsers/string_parser.ex
+++ b/lib/surgex/parser/parsers/string_parser.ex
@@ -4,10 +4,11 @@ defmodule Surgex.Parser.StringParser do
   - **trim** is trimming whitespaces from the string, takes priority over min and max options
   - **min** is a minimal length of the string, returns :too_short error symbol
   - **max** is a maximal length of the string, returns :too_long error symbol
+  - **regex** - input string must match passed regular expression, this is done after trimming
   """
   @type errors :: :too_short | :too_long | :invalid_string
-  @type option :: {:trim, boolean()} | {:min, integer()} | {:max, integer()}
-  @opts [:trim, :min, :max]
+  @type option :: {:trim, boolean()} | {:min, integer()} | {:max, integer()} | {:regex, Regex.t()}
+  @opts [:trim, :min, :max, :regex]
 
   @spec call(term(), [option()]) :: {:ok, String.t() | nil} | {:error, errors()}
   def call(input, opts \\ [])
@@ -47,6 +48,7 @@ defmodule Surgex.Parser.StringParser do
     |> trim()
     |> validate_min()
     |> validate_max()
+    |> check_regex()
   end
 
   @spec trim(%{opts: list, value: String.t(), error: nil}) :: %{
@@ -91,6 +93,21 @@ defmodule Surgex.Parser.StringParser do
       is_nil(max_value) -> input
       String.length(value) <= max_value -> input
       true -> %{input | error: :too_long}
+    end
+  end
+
+  @spec check_regex(%{opts: list, value: String.t(), error: nil}) :: %{
+    opts: list,
+    value: String.t(),
+    error: nil | :bad_format
+  }
+  def check_regex(input = %{opts: opts, value: value}) do
+    regex = Keyword.get(opts, :regex)
+
+    cond do
+      is_nil(regex) -> input
+      Regex.match?(regex, value) -> input
+      true -> %{input | error: :bad_format}
     end
   end
 

--- a/lib/surgex/parser/parsers/string_parser.ex
+++ b/lib/surgex/parser/parsers/string_parser.ex
@@ -6,7 +6,7 @@ defmodule Surgex.Parser.StringParser do
   - **max** is a maximal length of the string, returns :too_long error symbol
   - **regex** - input string must match passed regular expression, this is done after trimming
   """
-  @type errors :: :too_short | :too_long | :invalid_string
+  @type errors :: :too_short | :too_long | :invalid_string | :bad_format
   @type option :: {:trim, boolean()} | {:min, integer()} | {:max, integer()} | {:regex, Regex.t()}
   @opts [:trim, :min, :max, :regex]
 

--- a/lib/surgex/parser/parsers/uuid_parser.ex
+++ b/lib/surgex/parser/parsers/uuid_parser.ex
@@ -1,0 +1,22 @@
+defmodule Surgex.Parser.UuidParser do
+  @moduledoc """
+  This parser checks if the input is a proper UUID (with hyphens, case insentitive)
+  """
+
+  alias Surgex.Parser.StringParser
+
+  @uuid_regex ~r/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i
+
+  @spec call(term()) :: {:ok, String.t() | nil} | {:error, :invalid_uuid}
+  def call(nil), do: {:ok, nil}
+  def call(""), do: {:ok, nil}
+
+  def call(input) when is_binary(input) do
+    case StringParser.call(input, regex: @uuid_regex) do
+      {:ok, input} -> {:ok, input}
+      {:error, :bad_format} -> {:error, :invalid_uuid}
+    end
+  end
+
+  def call(_), do: {:error, :invalid_uuid}
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Surgex.Mixfile do
   def project do
     [
       app: :surgex,
-      version: "4.8.0",
+      version: "4.9.0",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,

--- a/test/surgex/parser/parser_test.exs
+++ b/test/surgex/parser/parser_test.exs
@@ -6,7 +6,8 @@ defmodule Surgex.ParserTest do
 
   @param_parsers [
     id: [:integer, :required],
-    uuid: [:string, :required],
+    uuid: [:uuid, :required],
+    uuid2: :uuid,
     price: [:float, :required],
     first_name: [:string, &RequiredParser.call/1],
     last_name: :string,
@@ -16,7 +17,7 @@ defmodule Surgex.ParserTest do
 
   @valid_params %{
     "id" => "123",
-    "uuid" => "asdf",
+    "uuid" => "123e4567-e89b-12d3-a456-426614174000",
     "price" => "10.5",
     "first-name" => "Jack",
     "last-name" => "",
@@ -25,6 +26,7 @@ defmodule Surgex.ParserTest do
 
   @invalid_params %{
     "id" => "abc",
+    "uuid2" => "asdf",
     "price" => "qwerty",
     "first-name" => "",
     "other-param" => "x",
@@ -88,7 +90,7 @@ defmodule Surgex.ParserTest do
                   last_name: nil,
                   first_name: "Jack",
                   price: 10.5,
-                  uuid: "asdf",
+                  uuid: "123e4567-e89b-12d3-a456-426614174000",
                   id: 123
                 ]}
     end
@@ -102,6 +104,7 @@ defmodule Surgex.ParserTest do
                   invalid_relationship_path: "include",
                   required: "first-name",
                   invalid_float: "price",
+                  invalid_uuid: "uuid2",
                   required: "uuid",
                   invalid_integer: "id",
                   unknown: "other-param"
@@ -277,7 +280,9 @@ defmodule Surgex.ParserTest do
     test "valid params" do
       parser_output = Parser.flat_parse(@valid_params, @param_parsers)
 
-      assert parser_output == {:ok, 123, "asdf", 10.5, "Jack", nil, nil, [:comments]}
+      assert parser_output ==
+               {:ok, 123, "123e4567-e89b-12d3-a456-426614174000", nil, 10.5, "Jack", nil, nil,
+                [:comments]}
     end
 
     test "invalid params" do
@@ -289,6 +294,7 @@ defmodule Surgex.ParserTest do
                   invalid_relationship_path: "include",
                   required: "first-name",
                   invalid_float: "price",
+                  invalid_uuid: "uuid2",
                   required: "uuid",
                   invalid_integer: "id",
                   unknown: "other-param"

--- a/test/surgex/parser/parsers/email_parser_test.exs
+++ b/test/surgex/parser/parsers/email_parser_test.exs
@@ -39,4 +39,16 @@ defmodule Surgex.Parser.EmailParserTest do
     assert EmailParser.call(0.5) == {:error, :invalid_email}
     assert EmailParser.call(["me@example@gmail.com"]) == {:error, :invalid_email}
   end
+
+  test "support min" do
+    assert EmailParser.call("short@co.uk", min: 15) == {:error, :too_short}
+  end
+
+  test "support max" do
+    assert EmailParser.call("very_long_email_this_is@fresha.com", max: 15) == {:error, :too_long}
+  end
+
+  test "support trim" do
+    assert EmailParser.call("    an_email@fresha.com  ", trim: true) == {:ok, "an_email@fresha.com"}
+  end
 end

--- a/test/surgex/parser/parsers/string_parser_test.exs
+++ b/test/surgex/parser/parsers/string_parser_test.exs
@@ -48,6 +48,7 @@ defmodule Surgex.Parser.StringParserTest do
 
   test "regex" do
     opt = [regex: ~r/^[a-h]{1,4}$/]
+    assert StringParser.call("", opt) == {:error, :bad_format}
     assert StringParser.call("abc", opt) == {:ok, "abc"}
     assert StringParser.call("axn", opt) == {:error, :bad_format}
     assert StringParser.call("abcde", opt) == {:error, :bad_format}

--- a/test/surgex/parser/parsers/string_parser_test.exs
+++ b/test/surgex/parser/parsers/string_parser_test.exs
@@ -46,6 +46,18 @@ defmodule Surgex.Parser.StringParserTest do
     assert StringParser.call("  abcde  ", opt) == {:error, :too_long}
   end
 
+  test "regex" do
+    opt = [regex: ~r/^[a-h]{1,4}$/]
+    assert StringParser.call("abc", opt) == {:ok, "abc"}
+    assert StringParser.call("axn", opt) == {:error, :bad_format}
+    assert StringParser.call("abcde", opt) == {:error, :bad_format}
+  end
+
+  test "regex check is done after trimming" do
+    opt = [regex: ~r/^[a-h]{1,4}$/, trim: true]
+    assert StringParser.call("  abc ", opt) == {:ok, "abc"}
+  end
+
   test "unsupported input type" do
     assert StringParser.call(1.4) == {:error, :invalid_string}
   end

--- a/test/surgex/parser/parsers/uuid_parse_test.exs
+++ b/test/surgex/parser/parsers/uuid_parse_test.exs
@@ -1,0 +1,36 @@
+defmodule Surgex.Parser.UuidParserTest do
+  use ExUnit.Case, async: true
+  alias Surgex.Parser.UuidParser
+
+  test "nil" do
+    assert UuidParser.call(nil) == {:ok, nil}
+  end
+
+  test "empty string" do
+    assert UuidParser.call("") == {:ok, nil}
+  end
+
+  test "valid uuid" do
+    uuid = "123e4567-e89b-12d3-a456-426614174000"
+    assert UuidParser.call(uuid) == {:ok, uuid}
+  end
+
+  test "uuid with wrong hyphenation" do
+    uuid = "123e4567-e89b-12d3-a456-42661417-4000"
+    assert UuidParser.call(uuid) == {:error, :invalid_uuid}
+  end
+
+  test "uuid with characters out of range" do
+    uuid = "123e4567-e89b-12d3-a456-426614174xyz"
+    assert UuidParser.call(uuid) == {:error, :invalid_uuid}
+  end
+
+  test "uppercase uuid" do
+    uuid = "123E4567-E89B-12D3-A456-426614174000"
+    assert UuidParser.call(uuid) == {:ok, uuid}
+  end
+
+  test "not a string" do
+    assert UuidParser.call(15) == {:error, :invalid_uuid}
+  end
+end


### PR DESCRIPTION
* Add `regex` option to `StringParser`, allowing specifying any kind of format constraints on an input
* Rewrite `EmailParser` to use the new option
* Add UUID parser limiting input to only valid UUIDs