### PR TITLE
Add default input value parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+
+## [4.12.0] - 2022-09-05
+
+- New parser (`Surgex.Parser.DefaultParser`) returning default values
+
 ## [4.11.0]
 
 - Added ability to return map with `Surgex.Parser.parse_map/2` function
@@ -282,8 +287,9 @@
 - Extended `Surgex.Sentry` to take release and environment from Mix
 - Completed `Surgex.Guide`
 
-[Unreleased]: https://github.com/surgeventures/surgex/compare/v4.11.0...HEAD
+[Unreleased]: https://github.com/surgeventures/surgex/compare/v4.12.0...HEAD
 
+[4.12.0]: https://github.com/surgeventures/surgex/compare/v4.11.0...v4.12.0
 [4.11.0]: https://github.com/surgeventures/surgex/compare/v4.10.0...v4.11.0
 [4.10.0]: https://github.com/surgeventures/surgex/compare/v4.9.0...v4.10.0
 [4.9.0]: https://github.com/surgeventures/surgex/compare/v4.8.0...v4.9.0

--- a/lib/surgex/parser/parsers/default_parser.ex
+++ b/lib/surgex/parser/parsers/default_parser.ex
@@ -1,0 +1,21 @@
+defmodule Surgex.Parser.DefaultParser do
+  @moduledoc """
+  Return default value for an empty input.
+  """
+
+  @empty_values [nil, ""]
+
+  @spec call(term(), term(), Keyword.t()) :: {:ok, term()}
+  def call(input_value, default_input_value, opts \\ []) do
+    empty_values = Keyword.get(opts, :empty_values, @empty_values)
+
+    if trim(input_value) in empty_values do
+      {:ok, default_input_value}
+    else
+      {:ok, input_value}
+    end
+  end
+
+  defp trim(input_value) when is_binary(input_value), do: String.trim(input_value)
+  defp trim(input_value), do: input_value
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Surgex.Mixfile do
   def project do
     [
       app: :surgex,
-      version: "4.11.0",
+      version: "4.12.0",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,

--- a/test/surgex/parser/parsers/default_parser_test.exs
+++ b/test/surgex/parser/parsers/default_parser_test.exs
@@ -1,0 +1,19 @@
+defmodule Surgex.Parser.DefaultParserTest do
+  use ExUnit.Case
+  alias Surgex.Parser.DefaultParser
+
+  test "returns default value for an empty input" do
+    assert DefaultParser.call(nil, "default") == {:ok, "default"}
+    assert DefaultParser.call(" ", "default") == {:ok, "default"}
+    assert DefaultParser.call([], "default", empty_values: [[]]) == {:ok, "default"}
+    assert DefaultParser.call(:empty, "default", empty_values: [:empty]) == {:ok, "default"}
+  end
+
+  test "passes through any non-empty input" do
+    assert DefaultParser.call("a value", "default") == {:ok, "a value"}
+    assert DefaultParser.call([], "default") == {:ok, []}
+    assert DefaultParser.call(false, "default") == {:ok, false}
+    assert DefaultParser.call("", "default", empty_values: [:empty]) == {:ok, ""}
+    assert DefaultParser.call(nil, "default", empty_values: [:empty]) == {:ok, nil}
+  end
+end


### PR DESCRIPTION
This PR introduces a new parser that substitutes any empty value with the provided default value. By default, empty values are defined as `nil` and empty string, but can be redefined per specific use case, see usage examples:

```elixir
parse(
  params,
  sort_order: [:string, {:default, "asc"}],
  status: :string,
  search: :string,
)
```

```elixir
parse(
  params,
  sort_order: [:string],
  status: [
    :resource_array,
    {:default, ["enabled"], empty_values: [[]]}
  ],
  search: :string,
)
```

add the `:default` parser first in the list of parsers to ensure that the provided default value is passed through all other parsers.

Notes:

Alternatively, we could add defaults to `params` before passing them to the `parse` function. But then we would be spreading param-related concerns across `Surgex` and the specific project that uses it. This seems to add convenience and is something that can be found in other param handling libraries (e.g. see [Params](https://hexdocs.pm/params/readme.html#usage) and [maru_params](https://github.com/elixir-maru/maru_params#atom)).