### PR TITLE
Set default max for IdParser

### DIFF
--- a/lib/surgex/parser/parsers/id_parser.ex
+++ b/lib/surgex/parser/parsers/id_parser.ex
@@ -32,9 +32,9 @@ defmodule Surgex.Parser.IdParser do
     max = Keyword.get(opts, :max)
 
     with {:ok, max} <- parse_max(max) do
-      case IntegerParser.call(input, max: max) do
-        {:ok, integer} when integer > 0 -> {:ok, integer}
-        {:ok, _invalid_integer} -> {:error, :invalid_identifier}
+      case IntegerParser.call(input, max: max, min: 1) do
+        {:ok, integer} -> {:ok, integer}
+        {:error, :out_of_range} -> {:error, :invalid_identifier}
         {:error, reason} -> {:error, reason}
       end
     end

--- a/lib/surgex/parser/parsers/id_parser.ex
+++ b/lib/surgex/parser/parsers/id_parser.ex
@@ -3,12 +3,25 @@ defmodule Surgex.Parser.IdParser do
 
   alias Surgex.Parser.IntegerParser
 
-  @type errors :: :invalid_identifier | IntegerParser.errors()
-  @type option :: {:max, integer()}
+  @type errors :: :invalid_identifier | :invalid_max | IntegerParser.errors()
+  @type numeric_id_types :: :int | :integer | :bigint | :biginteger | :serial | :bigserial
+  @type option :: {:max, integer() | numeric_id_types()}
 
   # This parser already validates that ids cannot be below zero
-  # therefore we don't handle the Postgres min integer case
-  @postgres_max_integer 2_147_483_647
+  # therefore we don't handle the minimum case
+  # See reference here for numeric types: https://www.postgresql.org/docs/current/datatype-numeric.html
+
+  @int8_max 9_223_372_036_854_775_807
+  @int4_max 2_147_483_647
+
+  @numeric_type_to_max_size %{
+    bigint: @int8_max,
+    biginteger: @int8_max,
+    bigserial: @int8_max,
+    int: @int4_max,
+    integer: @int4_max,
+    serial: @int4_max
+  }
 
   @spec call(term(), [option()]) :: {:ok, integer | nil} | {:error, errors}
   def call(input, opts \\ [])
@@ -16,14 +29,26 @@ defmodule Surgex.Parser.IdParser do
   def call("", _opts), do: {:ok, nil}
 
   def call(input, opts) when is_binary(input) do
-    max = Keyword.get(opts, :max, @postgres_max_integer)
+    max = Keyword.get(opts, :max)
 
-    case IntegerParser.call(input, max: max) do
-      {:ok, integer} when integer > 0 -> {:ok, integer}
-      {:ok, _invalid_integer} -> {:error, :invalid_identifier}
-      {:error, reason} -> {:error, reason}
+    with {:ok, max} <- parse_max(max) do
+      case IntegerParser.call(input, max: max) do
+        {:ok, integer} when integer > 0 -> {:ok, integer}
+        {:ok, _invalid_integer} -> {:error, :invalid_identifier}
+        {:error, reason} -> {:error, reason}
+      end
     end
   end
 
   def call(_input, _opts), do: {:error, :invalid_identifier}
+
+  def parse_max(max) when is_integer(max), do: {:ok, max}
+
+  for {type, size} <- @numeric_type_to_max_size do
+    def parse_max(unquote(type)), do: {:ok, unquote(size)}
+  end
+
+  def parse_max(nil), do: {:ok, nil}
+
+  def parse_max(_max), do: {:error, :invalid_max}
 end

--- a/lib/surgex/parser/parsers/id_parser.ex
+++ b/lib/surgex/parser/parsers/id_parser.ex
@@ -4,18 +4,26 @@ defmodule Surgex.Parser.IdParser do
   alias Surgex.Parser.IntegerParser
 
   @type errors :: :invalid_identifier | IntegerParser.errors()
+  @type option :: {:max, integer()}
 
-  @spec call(term()) :: {:ok, integer | nil} | {:error, errors}
-  def call(nil), do: {:ok, nil}
-  def call(""), do: {:ok, nil}
+  # This parser already validates that ids cannot be below zero
+  # therefore we don't handle the Postgres min integer case
+  @postgres_max_integer 2_147_483_647
 
-  def call(input) when is_binary(input) do
-    case IntegerParser.call(input) do
+  @spec call(term(), [option()]) :: {:ok, integer | nil} | {:error, errors}
+  def call(input, opts \\ [])
+  def call(nil, _opts), do: {:ok, nil}
+  def call("", _opts), do: {:ok, nil}
+
+  def call(input, opts) when is_binary(input) do
+    max = Keyword.get(opts, :max, @postgres_max_integer)
+
+    case IntegerParser.call(input, max: max) do
       {:ok, integer} when integer > 0 -> {:ok, integer}
       {:ok, _invalid_integer} -> {:error, :invalid_identifier}
       {:error, reason} -> {:error, reason}
     end
   end
 
-  def call(_input), do: {:error, :invalid_identifier}
+  def call(_input, _opts), do: {:error, :invalid_identifier}
 end

--- a/lib/surgex/parser/parsers/slug_or_id_parser.ex
+++ b/lib/surgex/parser/parsers/slug_or_id_parser.ex
@@ -3,14 +3,16 @@ defmodule Surgex.Parser.SlugOrIdParser do
 
   alias Surgex.Parser.IdParser
 
-  @spec call(term()) :: {:ok, String.t() | nil} | {:error, :invalid_slug}
-  def call(nil), do: {:ok, nil}
-  def call(""), do: {:ok, nil}
+  @spec call(term(), [IdParser.option()]) ::
+          {:ok, String.t() | nil} | {:error, :invalid_slug | IdParser.errors()}
+  def call(input, opts \\ [])
+  def call(nil, _opts), do: {:ok, nil}
+  def call("", _opts), do: {:ok, nil}
 
-  def call(input) when is_binary(input) do
+  def call(input, opts) when is_binary(input) do
     cond do
       String.match?(input, ~r/^\d+$/) ->
-        IdParser.call(input)
+        IdParser.call(input, opts)
 
       String.match?(input, ~r/^[a-zA-Z0-9\-]+$/) ->
         {:ok, input}
@@ -20,5 +22,5 @@ defmodule Surgex.Parser.SlugOrIdParser do
     end
   end
 
-  def call(_input), do: {:error, :invalid_slug}
+  def call(_input, _opts), do: {:error, :invalid_slug}
 end

--- a/test/surgex/parser/parsers/id_parser_test.exs
+++ b/test/surgex/parser/parsers/id_parser_test.exs
@@ -39,8 +39,8 @@ defmodule Surgex.Parser.IdParserTest do
     assert IdParser.call(to_string(@int8_max), max: :bigint) == {:ok, @int8_max}
     assert IdParser.call(to_string(@int8_max), max: :bigserial) == {:ok, @int8_max}
 
-    assert IdParser.call(to_string(@int4_max + 1), max: @int4_max) == {:error, :out_of_range}
-    assert IdParser.call(to_string(@int4_max + 1), max: :integer) == {:error, :out_of_range}
+    assert IdParser.call(to_string(@int4_max + 1), max: @int4_max) == {:error, :invalid_identifier}
+    assert IdParser.call(to_string(@int4_max + 1), max: :integer) == {:error, :invalid_identifier}
   end
 
   test "handles invalid max" do

--- a/test/surgex/parser/parsers/id_parser_test.exs
+++ b/test/surgex/parser/parsers/id_parser_test.exs
@@ -24,4 +24,18 @@ defmodule Surgex.Parser.IdParserTest do
     assert IdParser.call(1.5) == {:error, :invalid_identifier}
     assert IdParser.call(["1"]) == {:error, :invalid_identifier}
   end
+
+  @postgres_max_integer 2_147_483_647
+
+  test "by default enforces max based on 4 byte signed integers" do
+    assert IdParser.call(to_string(@postgres_max_integer)) == {:ok, @postgres_max_integer}
+    assert IdParser.call(to_string(@postgres_max_integer + 1)) == {:error, :out_of_range}
+  end
+
+  test "max is overridable" do
+    new_max = @postgres_max_integer + 1
+
+    assert IdParser.call(to_string(new_max), max: new_max) == {:ok, new_max}
+    assert IdParser.call(to_string(new_max + 1), max: new_max) == {:error, :out_of_range}
+  end
 end

--- a/test/surgex/parser/parsers/slug_or_id_parser_test.exs
+++ b/test/surgex/parser/parsers/slug_or_id_parser_test.exs
@@ -26,4 +26,9 @@ defmodule Surgex.Parser.SlugOrIdParserTest do
     assert SlugOrIdParser.call(0.3) == {:error, :invalid_slug}
     assert SlugOrIdParser.call(["123"]) == {:error, :invalid_slug}
   end
+
+  test "forwards options to id parser" do
+    assert SlugOrIdParser.call("123", max: 123) == {:ok, 123}
+    assert SlugOrIdParser.call("123", max: 122) == {:error, :invalid_identifier}
+  end
 end


### PR DESCRIPTION
We are getting errors such as [this one](https://sentry.io/organizations/surge-ventures/issues/2512676631) because certain params are out of the max integer range for Postgres, but are getting through the controller layer and being used in queries.

A good, DRY approach may to be to set a max id range in this library.