### PR TITLE
fix decimal parsing on different version of the module

### DIFF
--- a/lib/surgex/parser/parsers/decimal_parser.ex
+++ b/lib/surgex/parser/parsers/decimal_parser.ex
@@ -10,30 +10,30 @@ if Code.ensure_loaded?(Decimal) do
     def call(nil, _opts), do: {:ok, nil}
     def call("", _opts), do: {:ok, nil}
 
-    def call(input, opts) when is_integer(input) do
-      min = Keyword.get(opts, :min)
-      max = Keyword.get(opts, :max)
-
-      case Decimal.new(input) do
-        :error -> {:error, :invalid_decimal}
-        decimal -> validate_range(decimal, min, max)
-      end
-    end
-
     def call(input, opts) when is_binary(input) do
-      min = Keyword.get(opts, :min)
-      max = Keyword.get(opts, :max)
-
       case Decimal.parse(input) do
         :error -> {:error, :invalid_decimal}
-        {decimal, ""} -> validate_range(decimal, min, max)
+        {:ok, decimal} -> validate_range(decimal, opts)
+        {decimal, ""} -> validate_range(decimal, opts)
         {_decimal, _} -> {:error, :invalid_decimal}
       end
     end
 
-    def call(_input, _opts), do: {:error, :invalid_decimal}
+    def call(input, opts) when is_integer(input) do
+      case Decimal.new(input) do
+        :error -> {:error, :invalid_decimal}
+        decimal -> validate_range(decimal, opts)
+      end
+    end
 
-    defp validate_range(decimal, min, max) do
+    def call(_input, _opts) do
+      {:error, :invalid_decimal}
+    end
+
+    defp validate_range(decimal, opts) do
+      min = Keyword.get(opts, :min)
+      max = Keyword.get(opts, :max)
+
       if (is_integer(min) and Decimal.lt?(decimal, min)) or
            (is_integer(max) and Decimal.gt?(decimal, max)) do
         {:error, :out_of_range}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Surgex.Mixfile do
   def project do
     [
       app: :surgex,
-      version: "4.13.0",
+      version: "4.13.1",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,

--- a/test/surgex/parser/parsers/decimal_parser_test.exs
+++ b/test/surgex/parser/parsers/decimal_parser_test.exs
@@ -29,4 +29,16 @@ defmodule Surgex.Parser.DecimalParserTest do
     assert DecimalParser.call([1]) == {:error, :invalid_decimal}
     assert DecimalParser.call(%{test: 1}) == {:error, :invalid_decimal}
   end
+
+  test "valid range input" do
+    assert DecimalParser.call(1, min: 0, max: 10) == {:ok, Decimal.new("1")}
+    assert DecimalParser.call(1, min: 0) == {:ok, Decimal.new("1")}
+    assert DecimalParser.call(1, max: 10) == {:ok, Decimal.new("1")}
+  end
+
+  test "invalid range input" do
+    assert DecimalParser.call(1, min: 10, max: 100) == {:error, :out_of_range}
+    assert DecimalParser.call(1, min: 10) == {:error, :out_of_range}
+    assert DecimalParser.call(10, max: 1) == {:error, :out_of_range}
+  end
 end


### PR DESCRIPTION
It turn's out that Decimal.parse can have different type of output depending on the module version
`{Decimal.new(10), ""}`, `{:ok, Decimal.new(10)}`
also adds some tests