### PR TITLE
Handle nil values in IdListParser

### DIFF
--- a/lib/surgex/parser/parsers/id_list_parser.ex
+++ b/lib/surgex/parser/parsers/id_list_parser.ex
@@ -46,7 +46,7 @@ defmodule Surgex.Parser.IdListParser do
     {:ok, [id | previous_ids]}
   end
 
-  defp reduce_ids(id, {:ok, _previous_ids}) when is_integer(id) do
+  defp reduce_ids(_id, {:ok, _previous_ids}) do
     {:error, :invalid_identifier}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Surgex.Mixfile do
   def project do
     [
       app: :surgex,
-      version: "4.14.0",
+      version: "4.14.1",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,

--- a/test/surgex/parser/parsers/id_list_parser_test.exs
+++ b/test/surgex/parser/parsers/id_list_parser_test.exs
@@ -25,6 +25,7 @@ defmodule Surgex.Parser.IdListParserTest do
     assert IdListParser.call(["1", "2", "three"]) == {:error, :invalid_integer}
     assert IdListParser.call([1, -2, 3]) == {:error, :invalid_identifier}
     assert IdListParser.call(["1", "-2", "3"]) == {:error, :invalid_identifier}
+    assert IdListParser.call([nil]) == {:error, :invalid_identifier}
   end
 
   test "unsupported input type" do


### PR DESCRIPTION
It was failing when parsing a list containing a `nil` value:
```
iex> Surgex.Parser.IdListParser.call([nil])

** (FunctionClauseError) no function clause matching in Surgex.Parser.IdListParser.reduce_ids/2

The following arguments were given to Surgex.Parser.IdListParser.reduce_ids/2:

    # 1
    nil

    # 2
    {:ok, []}

Attempted function clauses (showing 4 out of 4):

    defp reduce_ids(_, {:error, reason})
    defp reduce_ids(id_string, {:ok, previous_ids}) when is_binary(id_string)
    defp reduce_ids(id, {:ok, previous_ids}) when is_integer(id) and id > 0
    defp reduce_ids(id, {:ok, _previous_ids}) when is_integer(id)
```

It's because the previous implementation expected the list items always to be a string or an integer but we had cases when FE was sending a list containing `nil` as well. 