### PR TITLE
Ensure Jabbax and Plug are loaded before defining a module in which they're required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [4.15.1]
+
+-  Make sure
+
+    1. Jabbax is loaded before we define `Surgex.Parser`
+    2. Plug is loaded before we define `Surgex.Sentry`
+
+to avoid compilation issues in apps that depend on Surgex.
+
 ## [4.15.0]
 
 - Discard unexpected parameters instead of returning 400 Bad Request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,10 @@
 
 ## [4.15.1]
 
--  Make sure
+-  Fix optional dependency on `Jabbax` and `Plug` by:
 
-    1. Jabbax is loaded before we define `Surgex.Parser`
-    2. Plug is loaded before we define `Surgex.Sentry`
-
-to avoid compilation issues in apps that depend on Surgex.
+    1. defining `Surgex.Parser` only if `Jabbax` is available
+    2. defining `Surgex.Sentry` only if `Plug` is available
 
 ## [4.15.0]
 

--- a/lib/surgex/parser/parser.ex
+++ b/lib/surgex/parser/parser.ex
@@ -1,327 +1,331 @@
-defmodule Surgex.Parser do
-  @moduledoc """
-  Parses, casts and catches errors in the web request input, such as params or JSON API body.
+if Code.ensure_loaded?(Jabbax) do
+  defmodule Surgex.Parser do
+    @moduledoc """
+    Parses, casts and catches errors in the web request input, such as params or JSON API body.
 
-  ## Usage
+    ## Usage
 
-  In order to use it, you should import the `Surgex.Parser` module, possibly in the `controller`
-  macro in the `web.ex` file belonging to your Phoenix project, which will make functions like
-  `parse` available in all controllers.
+    In order to use it, you should import the `Surgex.Parser` module, possibly in the `controller`
+    macro in the `web.ex` file belonging to your Phoenix project, which will make functions like
+    `parse` available in all controllers.
 
-  Then, you should start implementing functions for parsing params or documents for specific
-  controller actions. Those functions will serve as documentation crucial for understanding specific
-  action's input, so it's best to keep them close to the relevant action. For example:
+    Then, you should start implementing functions for parsing params or documents for specific
+    controller actions. Those functions will serve as documentation crucial for understanding specific
+    action's input, so it's best to keep them close to the relevant action. For example:
 
-      def index(conn, params) do
-        with {:ok, opts} <- parse_index_params(params) do
-          render(conn, locations: Marketplace.search_locations(opts))
-        else
-          {:error, :invalid_parameters, params} -> {:error, :invalid_parameters, params}
-        end
-      end
-
-      defp parse_index_params(params) do
-        parse params,
-          query: [:string, :required],
-          center: :geolocation,
-          box: :box,
-          category_id: :id,
-          subcategory_ids: :id_list,
-          sort: {:sort, ~w{price_min published_at distance}a},
-          page: :page
-      end
-
-  The second argument to `parse/2` and `flat_parse/2` is a param spec in which keys are resulting
-  option names and values are parser functions, atoms, tuples or lists used to process specific
-  parameter. Here's how each work:
-
-  - **parser functions** are functions that take the input value as first argument and can take
-    arbitrary amount of additional arguments as parser options; in order to pass such parser it's
-    best to use the `&` operator in format `&parser/1` or in case of parser options
-    `&parser(&1, opts...)`
-
-  - **parser atoms** point to built-in parsers by looking up a
-    `Surgex.Parser.<camelized-name>Parser` module and invoking the `call` function within it,
-    where the `call` function is just a parser function described above; for example `:integer` is
-    an equivalent to `&Surgex.Parser.IntegerParser.call/1`
-
-  - **parser tuples** allow to pass additional options to built-in parsers; the tuple starts with
-    the parser atom described above, followed by parser arguments matching the number of additional
-    arguments consumed by the parser; for example `{:sort, ~w{price_min published_at}a}`
-
-  - **parser lists** allow to pass a list of parser functions, atoms or tuples, all of which will be
-    parsed in a sequence in which the output from previous parser is piped to the next one and in
-    which the first failure stops the whole pipe; for example `[:integer, :required]`
-  """
-
-  @doc """
-  Parses controller action input (parameters, documents) with a given set of parsers.
-
-  Returns a keyword list with parsed options.
-  """
-  @spec parse(nil, any) :: {:error, :empty_input}
-  @spec parse(map, list) ::
-          {:ok, any} | {:error, :invalid_parameters, list} | {:error, :invalid_pointers, list}
-  def parse(input, parsers)
-
-  def parse(resource = %Jabbax.Document.Resource{}, parsers) do
-    parse_resource(resource, parsers)
-  end
-
-  def parse(doc = %Jabbax.Document{}, parsers) do
-    parse_doc(doc, parsers)
-  end
-
-  def parse(params = %{}, parsers) do
-    parse_params(params, parsers)
-  end
-
-  def parse(nil, _parsers), do: {:error, :empty_input}
-
-  @doc """
-  Parses controller action input (parameters, documents) with a given set of parsers.
-
-  Returns a map with parsed options.
-  """
-  @spec parse_map(nil, any) :: {:error, :empty_input}
-  @spec parse_map(map, list) ::
-          {:ok, map} | {:error, :invalid_parameters, list} | {:error, :invalid_pointers, list}
-  def parse_map(input, parsers) do
-    input
-    |> parse(parsers)
-    |> case do
-      {:ok, list} -> {:ok, Map.new(list)}
-      error -> error
-    end
-  end
-
-  @doc """
-  Parses controller action input into a flat structure.
-
-  This function takes the same input as `parse/2` but it returns a `{:ok, value1, value2, ...}`
-  tuple instead of a `[key1: value1, key2: value2, ...]` keyword list.
-  """
-  @spec flat_parse(nil, any) :: {:error, :empty_input}
-  # any number of params could be parsed, so the best spec for {:ok, v1, v2, vn} is tuple()
-  @spec flat_parse(map, list) ::
-          tuple() | {:error, :invalid_parameters, list} | {:error, :invalid_pointers, list}
-  def flat_parse(input, parsers)
-
-  def flat_parse(doc = %Jabbax.Document{}, parsers) do
-    with {:ok, list} <- parse_doc(doc, parsers, include_missing: true) do
-      output =
-        list
-        |> Keyword.values()
-        |> Enum.reverse()
-
-      List.to_tuple([:ok | output])
-    end
-  end
-
-  def flat_parse(params = %{}, parsers) do
-    with {:ok, list} <- parse_params(params, parsers, include_missing: true) do
-      output =
-        list
-        |> Keyword.values()
-        |> Enum.reverse()
-
-      List.to_tuple([:ok | output])
-    end
-  end
-
-  def flat_parse(nil, _parsers), do: {:error, :empty_input}
-
-  @doc """
-  Makes sure there are no unknown params passed to controller action.
-  """
-  @spec assert_blank_params(map) ::
-          :ok | {:error, :invalid_parameters, list} | {:error, :invalid_pointers, list}
-  def assert_blank_params(params) do
-    with {:ok, []} <- parse(params, []) do
-      :ok
-    end
-  end
-
-  @doc """
-  Renames keys in the parser output.
-  """
-  @spec map_parsed_options({:error, any}, any) :: {:error, any}
-  @spec map_parsed_options({:ok, any}, any) :: {:ok, any}
-  def map_parsed_options(parser_result, mapping) do
-    with {:ok, opts} <- parser_result do
-      updated_opts =
-        Enum.reduce(mapping, opts, fn {source, target}, current_opts ->
-          case Keyword.fetch(current_opts, source) do
-            {:ok, value} ->
-              current_opts
-              |> Keyword.delete(source)
-              |> Keyword.put(target, value)
-
-            :error ->
-              current_opts
+        def index(conn, params) do
+          with {:ok, opts} <- parse_index_params(params) do
+            render(conn, locations: Marketplace.search_locations(opts))
+          else
+            {:error, :invalid_parameters, params} -> {:error, :invalid_parameters, params}
           end
-        end)
-
-      {:ok, updated_opts}
-    end
-  end
-
-  defp parse_params(params, parsers, opts \\ []) do
-    {params, [], []}
-    |> pop_and_parse_keys(parsers, opts)
-    |> close_params()
-  end
-
-  defp parse_doc(doc, parsers, opts \\ [])
-
-  defp parse_doc(%{data: resource = %{}}, parsers, opts) do
-    resource
-    |> parse_resource(parsers, opts)
-    |> prefix_error_pointers("/data/")
-  end
-
-  defp parse_doc(_doc, _parsers, _opts) do
-    {:error, :invalid_pointers, [required: "/data"]}
-  end
-
-  defp parse_resource(resource, parsers, opts \\ []) do
-    {root_output, root_errors} = parse_resource_root(resource, parsers, opts)
-
-    {attribute_output, attribute_errors} =
-      parse_resource_nested(resource, parsers, :attributes, opts)
-
-    {relationship_output, relationship_errors} =
-      parse_resource_nested(resource, parsers, :relationships, opts)
-
-    output = relationship_output ++ attribute_output ++ root_output
-    errors = root_errors ++ attribute_errors ++ relationship_errors
-
-    close_resource({output, errors})
-  end
-
-  defp parse_resource_root(resource, all_parsers, opts) do
-    parsers = Keyword.drop(all_parsers, [:attributes, :relationships])
-    input = Map.from_struct(resource)
-
-    pop_and_parse_keys({input, [], []}, parsers, [stringify: false] ++ opts)
-  end
-
-  defp parse_resource_nested(resource, all_parsers, key, opts) do
-    parsers = Keyword.get(all_parsers, key, [])
-    attributes = Map.get(resource, key, %{})
-
-    {output, errors} = pop_and_parse_keys({attributes, [], []}, parsers, opts)
-
-    prefixed_errors = prefix_error_pointers(errors, "#{key}/")
-
-    {output, prefixed_errors}
-  end
-
-  defp prefix_error_pointers(payload, prefix) when is_tuple(payload) do
-    with {:error, reason, pointers} when is_list(pointers) <- payload do
-      {:error, reason, prefix_error_pointers(pointers, prefix)}
-    end
-  end
-
-  defp prefix_error_pointers(errors, prefix) when is_list(errors) do
-    Enum.map(errors, &prefix_error_pointer(&1, prefix))
-  end
-
-  defp prefix_error_pointer({reason, key}, prefix), do: {reason, "#{prefix}#{key}"}
-
-  defp pop_and_parse_keys(payload, key_parsers, opts) do
-    {_, output, errors} = Enum.reduce(key_parsers, payload, &pop_and_parse_keys_each(&1, &2, opts))
-    {output, errors}
-  end
-
-  defp pop_and_parse_keys_each({key, parser}, current_payload, opts) do
-    pop_and_parse_key(current_payload, {key, opts}, parser, key)
-  end
-
-  # credo:disable-for-next-line Credo.Check.Refactor.ABCSize
-  defp pop_and_parse_key({map, output, errors}, {input_key, opts}, parser, output_key) do
-    stringify = Keyword.get(opts, :stringify, true)
-    include_missing = Keyword.get(opts, :include_missing, false)
-
-    {{input_value, remaining_map}, used_key} = pop(map, input_key, stringify)
-    had_key = Map.has_key?(map, used_key)
-    drop_nil = not include_missing and not had_key
-
-    case call_parser(parser, input_value) do
-      {:ok, nil} ->
-        if drop_nil do
-          {remaining_map, output, errors}
-        else
-          final_output = Keyword.put_new(output, output_key, nil)
-          {remaining_map, final_output, errors}
         end
 
-      {:ok, parser_output} ->
-        final_output = Keyword.put_new(output, output_key, parser_output)
-        {remaining_map, final_output, errors}
+        defp parse_index_params(params) do
+          parse params,
+            query: [:string, :required],
+            center: :geolocation,
+            box: :box,
+            category_id: :id,
+            subcategory_ids: :id_list,
+            sort: {:sort, ~w{price_min published_at distance}a},
+            page: :page
+        end
 
-      {:error, new_errors} when is_list(new_errors) ->
-        prefixed_new_errors =
-          Enum.map(new_errors, fn {reason, pointer} ->
-            {reason, "#{used_key}/#{pointer}"}
+    The second argument to `parse/2` and `flat_parse/2` is a param spec in which keys are resulting
+    option names and values are parser functions, atoms, tuples or lists used to process specific
+    parameter. Here's how each work:
+
+    - **parser functions** are functions that take the input value as first argument and can take
+      arbitrary amount of additional arguments as parser options; in order to pass such parser it's
+      best to use the `&` operator in format `&parser/1` or in case of parser options
+      `&parser(&1, opts...)`
+
+    - **parser atoms** point to built-in parsers by looking up a
+      `Surgex.Parser.<camelized-name>Parser` module and invoking the `call` function within it,
+      where the `call` function is just a parser function described above; for example `:integer` is
+      an equivalent to `&Surgex.Parser.IntegerParser.call/1`
+
+    - **parser tuples** allow to pass additional options to built-in parsers; the tuple starts with
+      the parser atom described above, followed by parser arguments matching the number of additional
+      arguments consumed by the parser; for example `{:sort, ~w{price_min published_at}a}`
+
+    - **parser lists** allow to pass a list of parser functions, atoms or tuples, all of which will be
+      parsed in a sequence in which the output from previous parser is piped to the next one and in
+      which the first failure stops the whole pipe; for example `[:integer, :required]`
+    """
+
+    @doc """
+    Parses controller action input (parameters, documents) with a given set of parsers.
+
+    Returns a keyword list with parsed options.
+    """
+    @spec parse(nil, any) :: {:error, :empty_input}
+    @spec parse(map, list) ::
+            {:ok, any} | {:error, :invalid_parameters, list} | {:error, :invalid_pointers, list}
+    def parse(input, parsers)
+
+    def parse(resource = %Jabbax.Document.Resource{}, parsers) do
+      parse_resource(resource, parsers)
+    end
+
+    def parse(doc = %Jabbax.Document{}, parsers) do
+      parse_doc(doc, parsers)
+    end
+
+    def parse(params = %{}, parsers) do
+      parse_params(params, parsers)
+    end
+
+    def parse(nil, _parsers), do: {:error, :empty_input}
+
+    @doc """
+    Parses controller action input (parameters, documents) with a given set of parsers.
+
+    Returns a map with parsed options.
+    """
+    @spec parse_map(nil, any) :: {:error, :empty_input}
+    @spec parse_map(map, list) ::
+            {:ok, map} | {:error, :invalid_parameters, list} | {:error, :invalid_pointers, list}
+    def parse_map(input, parsers) do
+      input
+      |> parse(parsers)
+      |> case do
+        {:ok, list} -> {:ok, Map.new(list)}
+        error -> error
+      end
+    end
+
+    @doc """
+    Parses controller action input into a flat structure.
+
+    This function takes the same input as `parse/2` but it returns a `{:ok, value1, value2, ...}`
+    tuple instead of a `[key1: value1, key2: value2, ...]` keyword list.
+    """
+    @spec flat_parse(nil, any) :: {:error, :empty_input}
+    # any number of params could be parsed, so the best spec for {:ok, v1, v2, vn} is tuple()
+    @spec flat_parse(map, list) ::
+            tuple() | {:error, :invalid_parameters, list} | {:error, :invalid_pointers, list}
+    def flat_parse(input, parsers)
+
+    def flat_parse(doc = %Jabbax.Document{}, parsers) do
+      with {:ok, list} <- parse_doc(doc, parsers, include_missing: true) do
+        output =
+          list
+          |> Keyword.values()
+          |> Enum.reverse()
+
+        List.to_tuple([:ok | output])
+      end
+    end
+
+    def flat_parse(params = %{}, parsers) do
+      with {:ok, list} <- parse_params(params, parsers, include_missing: true) do
+        output =
+          list
+          |> Keyword.values()
+          |> Enum.reverse()
+
+        List.to_tuple([:ok | output])
+      end
+    end
+
+    def flat_parse(nil, _parsers), do: {:error, :empty_input}
+
+    @doc """
+    Makes sure there are no unknown params passed to controller action.
+    """
+    @spec assert_blank_params(map) ::
+            :ok | {:error, :invalid_parameters, list} | {:error, :invalid_pointers, list}
+    def assert_blank_params(params) do
+      with {:ok, []} <- parse(params, []) do
+        :ok
+      end
+    end
+
+    @doc """
+    Renames keys in the parser output.
+    """
+    @spec map_parsed_options({:error, any}, any) :: {:error, any}
+    @spec map_parsed_options({:ok, any}, any) :: {:ok, any}
+    def map_parsed_options(parser_result, mapping) do
+      with {:ok, opts} <- parser_result do
+        updated_opts =
+          Enum.reduce(mapping, opts, fn {source, target}, current_opts ->
+            case Keyword.fetch(current_opts, source) do
+              {:ok, value} ->
+                current_opts
+                |> Keyword.delete(source)
+                |> Keyword.put(target, value)
+
+              :error ->
+                current_opts
+            end
           end)
 
-        final_errors = prefixed_new_errors ++ errors
-        {remaining_map, output, final_errors}
-
-      {:error, reason} ->
-        final_errors = [{reason, used_key} | errors]
-        {remaining_map, output, final_errors}
+        {:ok, updated_opts}
+      end
     end
-  end
 
-  defp parse_in_sequence(input, [first_parser | other_parsers]) do
-    Enum.reduce(other_parsers, call_parser(first_parser, input), &parse_in_sequence_each/2)
-  end
-
-  defp parse_in_sequence_each(_next_parser, {:error, reason}), do: {:error, reason}
-
-  defp parse_in_sequence_each(next_parser, {:ok, prev_output}) do
-    call_parser(next_parser, prev_output)
-  end
-
-  defp call_parser(parsers, input) when is_list(parsers), do: parse_in_sequence(input, parsers)
-  defp call_parser(parser, input) when is_function(parser), do: parser.(input)
-  defp call_parser(parser, input) when is_atom(parser), do: call_parser({parser}, input)
-
-  defp call_parser(parser_tuple, input) when is_tuple(parser_tuple) do
-    [parser_name | parser_args] = Tuple.to_list(parser_tuple)
-
-    parser_camelized =
-      parser_name
-      |> Atom.to_string()
-      |> Macro.camelize()
-
-    parser_module = String.to_existing_atom("Elixir.Surgex.Parser.#{parser_camelized}Parser")
-
-    apply(parser_module, :call, [input | parser_args])
-  end
-
-  defp pop(map, key, stringify)
-
-  defp pop(map, key, false) do
-    {Map.pop(map, key), key}
-  end
-
-  defp pop(map, key, true) do
-    key_string = Atom.to_string(key)
-
-    if Map.has_key?(map, key_string) do
-      {Map.pop(map, key_string), key_string}
-    else
-      dasherized_key = String.replace(key_string, "_", "-")
-      {Map.pop(map, dasherized_key), dasherized_key}
+    defp parse_params(params, parsers, opts \\ []) do
+      {params, [], []}
+      |> pop_and_parse_keys(parsers, opts)
+      |> close_params()
     end
+
+    defp parse_doc(doc, parsers, opts \\ [])
+
+    defp parse_doc(%{data: resource = %{}}, parsers, opts) do
+      resource
+      |> parse_resource(parsers, opts)
+      |> prefix_error_pointers("/data/")
+    end
+
+    defp parse_doc(_doc, _parsers, _opts) do
+      {:error, :invalid_pointers, [required: "/data"]}
+    end
+
+    defp parse_resource(resource, parsers, opts \\ []) do
+      {root_output, root_errors} = parse_resource_root(resource, parsers, opts)
+
+      {attribute_output, attribute_errors} =
+        parse_resource_nested(resource, parsers, :attributes, opts)
+
+      {relationship_output, relationship_errors} =
+        parse_resource_nested(resource, parsers, :relationships, opts)
+
+      output = relationship_output ++ attribute_output ++ root_output
+      errors = root_errors ++ attribute_errors ++ relationship_errors
+
+      close_resource({output, errors})
+    end
+
+    defp parse_resource_root(resource, all_parsers, opts) do
+      parsers = Keyword.drop(all_parsers, [:attributes, :relationships])
+      input = Map.from_struct(resource)
+
+      pop_and_parse_keys({input, [], []}, parsers, [stringify: false] ++ opts)
+    end
+
+    defp parse_resource_nested(resource, all_parsers, key, opts) do
+      parsers = Keyword.get(all_parsers, key, [])
+      attributes = Map.get(resource, key, %{})
+
+      {output, errors} = pop_and_parse_keys({attributes, [], []}, parsers, opts)
+
+      prefixed_errors = prefix_error_pointers(errors, "#{key}/")
+
+      {output, prefixed_errors}
+    end
+
+    defp prefix_error_pointers(payload, prefix) when is_tuple(payload) do
+      with {:error, reason, pointers} when is_list(pointers) <- payload do
+        {:error, reason, prefix_error_pointers(pointers, prefix)}
+      end
+    end
+
+    defp prefix_error_pointers(errors, prefix) when is_list(errors) do
+      Enum.map(errors, &prefix_error_pointer(&1, prefix))
+    end
+
+    defp prefix_error_pointer({reason, key}, prefix), do: {reason, "#{prefix}#{key}"}
+
+    defp pop_and_parse_keys(payload, key_parsers, opts) do
+      {_, output, errors} =
+        Enum.reduce(key_parsers, payload, &pop_and_parse_keys_each(&1, &2, opts))
+
+      {output, errors}
+    end
+
+    defp pop_and_parse_keys_each({key, parser}, current_payload, opts) do
+      pop_and_parse_key(current_payload, {key, opts}, parser, key)
+    end
+
+    # credo:disable-for-next-line Credo.Check.Refactor.ABCSize
+    defp pop_and_parse_key({map, output, errors}, {input_key, opts}, parser, output_key) do
+      stringify = Keyword.get(opts, :stringify, true)
+      include_missing = Keyword.get(opts, :include_missing, false)
+
+      {{input_value, remaining_map}, used_key} = pop(map, input_key, stringify)
+      had_key = Map.has_key?(map, used_key)
+      drop_nil = not include_missing and not had_key
+
+      case call_parser(parser, input_value) do
+        {:ok, nil} ->
+          if drop_nil do
+            {remaining_map, output, errors}
+          else
+            final_output = Keyword.put_new(output, output_key, nil)
+            {remaining_map, final_output, errors}
+          end
+
+        {:ok, parser_output} ->
+          final_output = Keyword.put_new(output, output_key, parser_output)
+          {remaining_map, final_output, errors}
+
+        {:error, new_errors} when is_list(new_errors) ->
+          prefixed_new_errors =
+            Enum.map(new_errors, fn {reason, pointer} ->
+              {reason, "#{used_key}/#{pointer}"}
+            end)
+
+          final_errors = prefixed_new_errors ++ errors
+          {remaining_map, output, final_errors}
+
+        {:error, reason} ->
+          final_errors = [{reason, used_key} | errors]
+          {remaining_map, output, final_errors}
+      end
+    end
+
+    defp parse_in_sequence(input, [first_parser | other_parsers]) do
+      Enum.reduce(other_parsers, call_parser(first_parser, input), &parse_in_sequence_each/2)
+    end
+
+    defp parse_in_sequence_each(_next_parser, {:error, reason}), do: {:error, reason}
+
+    defp parse_in_sequence_each(next_parser, {:ok, prev_output}) do
+      call_parser(next_parser, prev_output)
+    end
+
+    defp call_parser(parsers, input) when is_list(parsers), do: parse_in_sequence(input, parsers)
+    defp call_parser(parser, input) when is_function(parser), do: parser.(input)
+    defp call_parser(parser, input) when is_atom(parser), do: call_parser({parser}, input)
+
+    defp call_parser(parser_tuple, input) when is_tuple(parser_tuple) do
+      [parser_name | parser_args] = Tuple.to_list(parser_tuple)
+
+      parser_camelized =
+        parser_name
+        |> Atom.to_string()
+        |> Macro.camelize()
+
+      parser_module = String.to_existing_atom("Elixir.Surgex.Parser.#{parser_camelized}Parser")
+
+      apply(parser_module, :call, [input | parser_args])
+    end
+
+    defp pop(map, key, stringify)
+
+    defp pop(map, key, false) do
+      {Map.pop(map, key), key}
+    end
+
+    defp pop(map, key, true) do
+      key_string = Atom.to_string(key)
+
+      if Map.has_key?(map, key_string) do
+        {Map.pop(map, key_string), key_string}
+      else
+        dasherized_key = String.replace(key_string, "_", "-")
+        {Map.pop(map, dasherized_key), dasherized_key}
+      end
+    end
+
+    defp close_params({output, []}), do: {:ok, output}
+    defp close_params({_output, errors}), do: {:error, :invalid_parameters, errors}
+
+    defp close_resource({output, []}), do: {:ok, output}
+    defp close_resource({_output, errors}), do: {:error, :invalid_pointers, errors}
   end
-
-  defp close_params({output, []}), do: {:ok, output}
-  defp close_params({_output, errors}), do: {:error, :invalid_parameters, errors}
-
-  defp close_resource({output, []}), do: {:ok, output}
-  defp close_resource({_output, errors}), do: {:error, :invalid_pointers, errors}
 end

--- a/lib/surgex/sentry/sentry.ex
+++ b/lib/surgex/sentry/sentry.ex
@@ -1,101 +1,103 @@
-defmodule Surgex.Sentry do
-  @moduledoc """
-  Extensions to the official Sentry package.
+if Code.ensure_loaded?(Plug) do
+  defmodule Surgex.Sentry do
+    @moduledoc """
+    Extensions to the official Sentry package.
 
-  **NOTE: Deprecated in favor of Elixir 1.9 runtime configuration.**
-  """
+    **NOTE: Deprecated in favor of Elixir 1.9 runtime configuration.**
+    """
 
-  alias Mix.Project
+    alias Mix.Project
 
-  @doc """
-  Patches Sentry environment name and release version from env vars.
+    @doc """
+    Patches Sentry environment name and release version from env vars.
 
-  By default, Sentry package only allows to fetch DSN from env var. This function extends that
-  with environment name and release version set on runtime, thus enabling deployments on Heroku
-  where application slug is compiled without final env vars.
+    By default, Sentry package only allows to fetch DSN from env var. This function extends that
+    with environment name and release version set on runtime, thus enabling deployments on Heroku
+    where application slug is compiled without final env vars.
 
-  ## Examples
+    ## Examples
 
-  In order to execute this extension on application start, set an appropriate config key:
+    In order to execute this extension on application start, set an appropriate config key:
 
-      config :surgex,
-        sentry_patch_enabled: true
+        config :surgex,
+          sentry_patch_enabled: true
 
-  """
-  def init do
-    if Application.get_env(:surgex, :sentry_patch_enabled, false), do: do_init()
-  end
-
-  defp do_init do
-    require Logger
-
-    env = get_env()
-    release = get_release()
-
-    Logger.info(fn ->
-      "Patching Sentry config (environment: #{inspect(env)}, release: #{inspect(release)})"
-    end)
-
-    :ok =
-      Application.put_all_env(
-        sentry: [
-          release: release,
-          environment_name: env,
-          included_environments: [env]
-        ]
-      )
-  end
-
-  defp get_env do
-    case Application.get_env(:surgex, :sentry_environment, :mix_env) do
-      :mix_env ->
-        Mix.env()
-
-      value ->
-        Confix.parse(value)
+    """
+    def init do
+      if Application.get_env(:surgex, :sentry_patch_enabled, false), do: do_init()
     end
-  end
 
-  defp get_release do
-    case Application.get_env(:surgex, :sentry_release, :mix_version) do
-      :mix_version ->
-        Project.config()[:version]
+    defp do_init do
+      require Logger
 
-      value ->
-        Confix.parse(value)
+      env = get_env()
+      release = get_release()
+
+      Logger.info(fn ->
+        "Patching Sentry config (environment: #{inspect(env)}, release: #{inspect(release)})"
+      end)
+
+      :ok =
+        Application.put_all_env(
+          sentry: [
+            release: release,
+            environment_name: env,
+            included_environments: [env]
+          ]
+        )
     end
+
+    defp get_env do
+      case Application.get_env(:surgex, :sentry_environment, :mix_env) do
+        :mix_env ->
+          Mix.env()
+
+        value ->
+          Confix.parse(value)
+      end
+    end
+
+    defp get_release do
+      case Application.get_env(:surgex, :sentry_release, :mix_version) do
+        :mix_version ->
+          Project.config()[:version]
+
+        value ->
+          Confix.parse(value)
+      end
+    end
+
+    @scrubbed_param_keys Application.compile_env(:surgex, :sentry_scrubbed_param_keys, ~w{password})
+    @scrubbed_value Application.compile_env(:surgex, :sentry_scrubbed_value, "[Filtered]")
+
+    @doc """
+    Deeply scrubs params, obfuscating those with blacklisted names.
+
+    By default, Sentry package only offers flat scrubbing of params. This won't work with nested
+    params or JSON objects, so here's deep recursive equivalent of such scrubber.
+
+    ## Examples
+
+    In order to use this extension, pass `Surgex.Sentry.scrub_params/1` to `Sentry.Plug` like this:
+
+        use Sentry.Plug, body_scrubber: &Surgex.Sentry.scrub_params/1
+
+    """
+    def scrub_params(%Plug.Conn{params: params}), do: scrub_map(params)
+
+    defp scrub_map(map = %{}) do
+      map
+      |> Enum.map(&scrub_map_item/1)
+      |> Map.new()
+    end
+
+    defp scrub_list(list), do: Enum.map(list, &scrub_value/1)
+
+    defp scrub_map_item({key, _value}) when key in @scrubbed_param_keys, do: {key, @scrubbed_value}
+    defp scrub_map_item({key, value}), do: {key, scrub_value(value)}
+
+    defp scrub_value(value) when is_map(value), do: scrub_map(value)
+    defp scrub_value(value) when is_list(value), do: scrub_list(value)
+    defp scrub_value(value), do: value
   end
-
-  @scrubbed_param_keys Application.compile_env(:surgex, :sentry_scrubbed_param_keys, ~w{password})
-  @scrubbed_value Application.compile_env(:surgex, :sentry_scrubbed_value, "[Filtered]")
-
-  @doc """
-  Deeply scrubs params, obfuscating those with blacklisted names.
-
-  By default, Sentry package only offers flat scrubbing of params. This won't work with nested
-  params or JSON objects, so here's deep recursive equivalent of such scrubber.
-
-  ## Examples
-
-  In order to use this extension, pass `Surgex.Sentry.scrub_params/1` to `Sentry.Plug` like this:
-
-      use Sentry.Plug, body_scrubber: &Surgex.Sentry.scrub_params/1
-
-  """
-  def scrub_params(%Plug.Conn{params: params}), do: scrub_map(params)
-
-  defp scrub_map(map = %{}) do
-    map
-    |> Enum.map(&scrub_map_item/1)
-    |> Map.new()
-  end
-
-  defp scrub_list(list), do: Enum.map(list, &scrub_value/1)
-
-  defp scrub_map_item({key, _value}) when key in @scrubbed_param_keys, do: {key, @scrubbed_value}
-  defp scrub_map_item({key, value}), do: {key, scrub_value(value)}
-
-  defp scrub_value(value) when is_map(value), do: scrub_map(value)
-  defp scrub_value(value) when is_list(value), do: scrub_list(value)
-  defp scrub_value(value), do: value
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Surgex.Mixfile do
   def project do
     [
       app: :surgex,
-      version: "4.15.0",
+      version: "4.15.1",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
Even though this compiles fine on its own, when you depend on Surgex, you can't compile it because you get

```
❯ mix deps.compile surgex
==> surgex
Compiling 47 files (.ex)

== Compilation error in file lib/surgex/parser/parser.ex ==
** (CompileError) lib/surgex/parser/parser.ex:67: Jabbax.Document.Resource.__struct__/0 is undefined, cannot expand struct Jabbax.Document.Resource. Make sure the struct name is correct. If the struct name exists and is correct but it still cannot be found, you likely have cyclic module usage in your code
    expanding struct: Jabbax.Document.Resource.__struct__/0
    lib/surgex/parser/parser.ex:67: Surgex.Parser.parse/2
could not compile dependency :surgex, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile surgex", update it with "mix deps.update surgex" or clean it with "mix deps.clean surgex"
```

```
❯ mix deps.compile surgex
==> surgex
Compiling 47 files (.ex)

== Compilation error in file lib/surgex/sentry/sentry.ex ==
** (CompileError) lib/surgex/sentry/sentry.ex:85: Plug.Conn.__struct__/0 is undefined, cannot expand struct Plug.Conn. Make sure the struct name is correct. If the struct name exists and is correct but it
 still cannot be found, you likely have cyclic module usage in your code
    expanding struct: Plug.Conn.__struct__/0
    lib/surgex/sentry/sentry.ex:85: Surgex.Sentry.scrub_params/1
could not compile dependency :surgex, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile surgex", update it with "mix deps.update surgex" or
clean it with "mix deps.clean surgex"
```

### How to reproduce?

1. Just create a new app

```
mix new foobar --sup
```

2. Then add surgex as a dependency to your `mix.exs`

```
  defp deps do
    [
      {:surgex, "~> 4.7"},
    ]
  end
```

3. Run `mix deps.compile surgex` and you'll get the compilation errors I've listed above.

So in those files mentioned in the errors, we're still depending on the structs that come from those packages ([1](https://github.com/surgeventures/surgex/blob/5806b48b9503f35ea97f37bf8c322a1990884848/lib/surgex/parser/parser.ex#L67-L73), [2](https://github.com/surgeventures/surgex/blob/5806b48b9503f35ea97f37bf8c322a1990884848/lib/surgex/sentry/sentry.ex#L85)). When it's marked as optional, however those packages are not loaded.

For `optional` [the documentation says](https://hexdocs.pm/mix/1.12/Mix.Tasks.Deps.html#module-dependency-definition-options)

> `:optional` - marks the dependency as optional. In such cases, the current project will always include the optional dependency but any other project that depends on the current project won't be forced to use the optional dependency. However, if the other project includes the optional dependency on its own, the requirements and options specified here will also be applied. Optional dependencies will not be started by the application.