### PR TITLE
Fixed deprecation by using Logger.warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [4.15.2]
+
+-  Using `Logger.warning` instead of deprecated `Logger.warn`
+
 ## [4.15.1]
 
 -  Fix optional dependency on `Jabbax` and `Plug` by:

--- a/lib/surgex/data_pipe/follower_sync.ex
+++ b/lib/surgex/data_pipe/follower_sync.ex
@@ -52,7 +52,7 @@ defmodule Surgex.DataPipe.FollowerSync do
         :ok
 
       !PostgresSystemUtils.lsn_valid?(lsn) ->
-        Logger.warn("Invalid LSN: #{inspect(lsn)}")
+        Logger.warning("Invalid LSN: #{inspect(lsn)}")
         {:error, :invalid_lsn}
 
       true ->
@@ -66,7 +66,7 @@ defmodule Surgex.DataPipe.FollowerSync do
         handle_lsn_update(repo, lsn, last_lsn, start_time)
 
       :error ->
-        Logger.warn(fn -> "No replay LSN (consider setting follower_sync_enabled: false)" end)
+        Logger.warning(fn -> "No replay LSN (consider setting follower_sync_enabled: false)" end)
         {:error, :no_replay_lsn}
     end
   end
@@ -83,7 +83,7 @@ defmodule Surgex.DataPipe.FollowerSync do
         :ok
 
       elapsed_time >= timeout ->
-        Logger.warn(fn -> "Follower sync timeout after #{timeout}ms: #{last_lsn} < #{lsn}" end)
+        Logger.warning(fn -> "Follower sync timeout after #{timeout}ms: #{last_lsn} < #{lsn}" end)
         {:error, :timeout}
 
       true ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,8 @@ defmodule Surgex.Mixfile do
   def project do
     [
       app: :surgex,
-      version: "4.15.1",
-      elixir: "~> 1.4",
+      version: "4.15.2",
+      elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
`Logger.warn` is deprecated. Using `Logger.warning` instead. 