### PR TITLE
chore: redirect actions to freshaengineering + pin to SHA

### DIFF
--- a/.github/actions.lock.yaml
+++ b/.github/actions.lock.yaml
@@ -1,0 +1,32 @@
+version: 1
+generated_at: 2026-06-11T15:40:51Z
+internal: []
+trusted:
+  - action: actions/cache
+    refs:
+      - 0057852bfaa89a56745cba8c7296529d2fc39830
+    occurrences:
+      0057852bfaa89a56745cba8c7296529d2fc39830:
+        .github/workflows/ci.yaml:
+          - jobs.test.steps.[2].uses
+  - action: actions/checkout
+    refs:
+      - 34e114876b0b11c390a56381ad16ebd13914f8d5
+    occurrences:
+      34e114876b0b11c390a56381ad16ebd13914f8d5:
+        .github/workflows/ci.yaml:
+          - jobs.test.steps.[0].uses
+          - jobs.permit.steps.[0].uses
+          - jobs.publish.steps.[0].uses
+external:
+  - action: erlef/setup-beam
+    refs:
+      - fc68ffb90438ef2936bbb3251622353b3dcb2f93
+    occurrences:
+      fc68ffb90438ef2936bbb3251622353b3dcb2f93:
+        .github/workflows/ci.yaml:
+          - jobs.test.steps.[1].uses
+          - jobs.publish.steps.[1].uses
+local: []
+docker: []
+dynamic: []

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ env:
   OTP_VERSION: 27.3
   DEBIAN_FRONTEND: noninteractive
   REPOSITORY: surgex
-  RUNNER_OS: ubuntu22 # Must match Elixir/OTP version in described in action erlef/setup-beam@v1
+  RUNNER_OS: ubuntu22 # Must match Elixir/OTP version in described in action erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
   ImageOS: ubuntu22
   DEPENDENCY_FILE: mix.lock
   WORKING_DIRECTORY: .
@@ -63,14 +63,14 @@ jobs:
       POSTGRES_PASSWORD: postgres
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             deps
@@ -90,7 +90,7 @@ jobs:
     outputs:
       PUBLISH: ${{ steps.version.outputs.PUBLISH }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 2
           ref: ${{ env.SHA }}
@@ -122,10 +122,10 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.permit.outputs.PUBLISH == 'true' && github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ env.SHA }}
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}


### PR DESCRIPTION
## Summary
- Redirects all `surgeventures/platform-tribe-actions` references to `freshaengineering/platform-tribe-actions`
- Pins **all** GitHub Actions to immutable commit SHAs — both external third-party actions and internal `platform-tribe-actions` references

## How it was generated

The following 5 commands were run in sequence from the repository root:

```
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
node platform-tribe-actions/.scripts/actions-lockfile-bump-internal.js
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
node platform-tribe-actions/.scripts/actions-lockfile-pin-external.js --pin-all
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
```

- `actions-lockfile-produce.js` — generates/updates `.github/actions.lock.yaml` from current workflow refs
- `actions-lockfile-bump-internal.js` — resolves internal (`platform-tribe-actions`) action refs to their current SHA
- `actions-lockfile-pin-external.js --pin-all` — resolves all external action refs to their current SHA