### PR TITLE
Migrate to step-security/mise-action for tool installation

### DIFF
--- a/.github/actions.lock.yaml
+++ b/.github/actions.lock.yaml
@@ -1,5 +1,5 @@
 version: 1
-generated_at: 2026-06-11T15:40:51Z
+generated_at: 2026-08-04T13:15:44Z
 internal: []
 trusted:
   - action: actions/cache
@@ -8,25 +8,35 @@ trusted:
     occurrences:
       0057852bfaa89a56745cba8c7296529d2fc39830:
         .github/workflows/ci.yaml:
-          - jobs.test.steps.[2].uses
+          - jobs.test.steps.[3].uses
   - action: actions/checkout
     refs:
       - 34e114876b0b11c390a56381ad16ebd13914f8d5
     occurrences:
       34e114876b0b11c390a56381ad16ebd13914f8d5:
         .github/workflows/ci.yaml:
+          - jobs.test.steps.[1].uses
+          - jobs.permit.steps.[1].uses
+          - jobs.publish.steps.[1].uses
+external:
+  - action: step-security/harden-runner
+    refs:
+      - 9af89fc71515a100421586dfdb3dc9c984fbf411
+    occurrences:
+      9af89fc71515a100421586dfdb3dc9c984fbf411:
+        .github/workflows/ci.yaml:
           - jobs.test.steps.[0].uses
           - jobs.permit.steps.[0].uses
           - jobs.publish.steps.[0].uses
-external:
-  - action: erlef/setup-beam
+  - action: step-security/mise-action
     refs:
-      - fc68ffb90438ef2936bbb3251622353b3dcb2f93
+      - 2796166110dee826668caddd4bffedae5116e7cd
     occurrences:
-      fc68ffb90438ef2936bbb3251622353b3dcb2f93:
+      2796166110dee826668caddd4bffedae5116e7cd:
         .github/workflows/ci.yaml:
-          - jobs.test.steps.[1].uses
-          - jobs.publish.steps.[1].uses
+          - jobs.test.steps.[2].uses
+          - jobs.publish.steps.[2].uses
 local: []
 docker: []
 dynamic: []
+nested_floating_deps: []

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Setup mise
         uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
         env:
-          MISE_ELIXIR_VERSION: ${{ matrix.elixir }}
+          MISE_ELIXIR_VERSION: ${{ matrix.elixir }}-otp-${{ matrix.otp }}
           MISE_ERLANG_VERSION: ${{ matrix.otp }}
 
       - uses: step-security/runs-on-cache@c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 # v5.0.7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,10 +71,11 @@ jobs:
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
-        with:
-          elixir-version: ${{ matrix.elixir }}
-          otp-version: ${{ matrix.otp }}
+      - name: Setup mise
+        uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
+        env:
+          MISE_ELIXIR_VERSION: ${{ matrix.elixir }}
+          MISE_ERLANG_VERSION: ${{ matrix.otp }}
 
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
@@ -143,11 +144,8 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ env.SHA }}
-      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
-        with:
-          elixir-version: ${{ env.ELIXIR_VERSION }}
-          otp-version: ${{ env.OTP_VERSION }}
-          version-type: strict
+      - name: Setup mise
+        uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
       - name: Get dependencies
         run: mix deps.get
       - name: Publish package

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,8 @@ jobs:
       POSTGRES_PORT: 5432
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
+      MISE_ELIXIR_VERSION: ${{ matrix.elixir }}-otp-${{ matrix.otp }}
+      MISE_ERLANG_VERSION: ${{ matrix.otp }}
 
     steps:
       - name: Harden the runner
@@ -73,9 +75,6 @@ jobs:
 
       - name: Setup mise
         uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
-        env:
-          MISE_ELIXIR_VERSION: ${{ matrix.elixir }}-otp-${{ matrix.otp }}
-          MISE_ERLANG_VERSION: ${{ matrix.otp }}
 
       - uses: step-security/runs-on-cache@c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 # v5.0.7
         with:

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-elixir = "1.18.3"
+elixir = "1.18.3-otp-27"
 erlang = "27.3"


### PR DESCRIPTION
## Summary
- Replace `erlef/setup-beam` with `step-security/mise-action`, per the org's mise migration.
- The `test` job's elixir/otp compatibility matrix (1.15/26 through 1.18/27) is preserved via `MISE_ELIXIR_VERSION`/`MISE_ERLANG_VERSION` env overrides driven by the matrix values.
- The publish job's `env.ELIXIR_VERSION`/`env.OTP_VERSION` (`1.18.3`/`27.3`) exactly match `mise.toml`, so it's a plain swap with no version change.
- Bump internal GHAs via alflow (if applicable).

## Test plan
- [ ] CI green on this PR (all matrix legs, publish job)
