### PR TITLE
Make timex an optional dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -67,7 +67,7 @@ defmodule Surgex.Mixfile do
       {:ecto_sql, "~> 3.0"},
       {:jabbax, "~> 0.2 or ~> 1.0"},
       {:plug, "~> 1.7"},
-      {:timex, "~> 3.7"}
+      {:timex, "~> 3.7", optional: true}
     ]
     |> Enum.map(&merge_dep_flags(&1, optional: true))
   end


### PR DESCRIPTION
`Surgex.DateTime` is the only module that touches Timex, and it is **already** guarded:

```elixir
if Code.ensure_loaded?(Timex) do
  defmodule Surgex.DateTime do
```

So the library already compiles and works without it. Making the dependency `optional: true` stops it being forced on every consumer.

## Why this matters beyond tidiness

**`timex` is on the org's banned-libs list.** surgex currently propagates it transitively into every consuming service, where ditto reports it as a banned-libs advisory the consumer has no way to fix — the dependency isn't theirs.

**`timex` caps `gettext` at `~> 0.26`**, blocking consumers from gettext 1.x. Even the latest timex (3.7.13) still requires `~> 0.26`, so there's no version that resolves it.

Verified against app-inventory by pointing it at this branch:

| | before | after |
|---|---|---|
| `timex` entries in `mix.lock` | 1 | **0** |
| `gettext` | 0.26.2 (capped) | **1.0.2** |

## Compatibility

Consumers that use `Surgex.DateTime` keep working by declaring `{:timex, "~> 3.7"}` themselves — the standard optional-dependency contract. Consumers that don't (the common case — it's one small date/time helper) simply stop carrying it.

## Verification

`mix test` — 2 doctests, 207 tests, 0 failures. Timex is still fetched for surgex's own build, since `optional: true` only affects consumers, so the `Surgex.DateTime` tests continue to exercise the real Timex path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)