### PR TITLE
ci: add timeout-minutes to workflow jobs (sized from CI history)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,6 +91,7 @@ jobs:
 
   permit:
     name: Permit Package Publishing
+    timeout-minutes: 25
     needs: [test]
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
Sets `timeout-minutes` on GitHub Actions jobs that had none, so a hung job
can't hold a runner for GitHub's 6-hour default.

**How the values were computed** — for each job, the last 100 *successful*
runs (90-day lookback) were pulled from Datadog CI Visibility; the timeout is
`ceil(max_duration) + 20` minutes of headroom, rounded up to the nearest
multiple of 5. Jobs that already declare a
`timeout-minutes` were left untouched, and jobs with no recent CI data were
skipped rather than given a guessed value.

Notes for review:
- Only `.github/workflows/*.y*ml` files are touched; one inserted line per job.
- Reusable-workflow *caller* jobs (`uses:`) are unchanged — GitHub doesn't
  allow `timeout-minutes` there; the limit lives on the called workflow's jobs.
- If a job is known to legitimately run longer than its history suggests
  (e.g. rare full rebuilds), bump the value in this PR rather than dropping it.

Part of the platform CI-hardening effort (freshaengineering/team-devex#483).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
