### PR TITLE
chore: retire asdf

### DIFF
--- a/.github/actions.lock.yaml
+++ b/.github/actions.lock.yaml
@@ -1,0 +1,42 @@
+version: 1
+generated_at: 2026-08-20T17:23:03Z
+internal: []
+trusted:
+  - action: actions/checkout
+    refs:
+      - 34e114876b0b11c390a56381ad16ebd13914f8d5
+    occurrences:
+      34e114876b0b11c390a56381ad16ebd13914f8d5:
+        .github/workflows/ci.yaml:
+          - jobs.test.steps.[1].uses
+          - jobs.permit.steps.[1].uses
+          - jobs.publish.steps.[1].uses
+external:
+  - action: step-security/harden-runner
+    refs:
+      - 9af89fc71515a100421586dfdb3dc9c984fbf411
+    occurrences:
+      9af89fc71515a100421586dfdb3dc9c984fbf411:
+        .github/workflows/ci.yaml:
+          - jobs.test.steps.[0].uses
+          - jobs.permit.steps.[0].uses
+          - jobs.publish.steps.[0].uses
+  - action: step-security/mise-action
+    refs:
+      - 2796166110dee826668caddd4bffedae5116e7cd
+    occurrences:
+      2796166110dee826668caddd4bffedae5116e7cd:
+        .github/workflows/ci.yaml:
+          - jobs.test.steps.[2].uses
+          - jobs.publish.steps.[2].uses
+  - action: step-security/runs-on-cache
+    refs:
+      - c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73
+    occurrences:
+      c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73:
+        .github/workflows/ci.yaml:
+          - jobs.test.steps.[3].uses
+local: []
+docker: []
+dynamic: []
+nested_floating_deps: []

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,6 @@ env:
   DEBIAN_FRONTEND: noninteractive
   REPOSITORY: surgex
   RUNNER_OS: ubuntu22 # Must match Elixir/OTP version in described in action erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
-  ImageOS: ubuntu22
   DEPENDENCY_FILE: mix.lock
   WORKING_DIRECTORY: .
 


### PR DESCRIPTION
## What changed in this repo

- Removed the obsolete `ImageOS: ubuntu22` line from the `env:` block in `.github/workflows/ci.yaml` (only workflow file with this pin). The neighboring `RUNNER_OS` comment was left intact since it documents RUNNER_OS/setup-beam version matching, not solely ImageOS.
- Bumped action pins via the internal alflow lockfile chain (produce -> bump-internal -> produce -> pin-external --pin-all -> produce).

Part of the org-wide asdf retirement rollout.